### PR TITLE
release: 1.1.0

### DIFF
--- a/.github/workflows/pr-title-validation.yml
+++ b/.github/workflows/pr-title-validation.yml
@@ -11,6 +11,8 @@ jobs:
   pr-title-check:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
       - name: Check PR Title Format
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
@@ -37,7 +39,6 @@ jobs:
               echo "❌ PR title must start with a valid prefix"
               echo "Current title: $PR_TITLE"
               echo "Valid prefixes: fix:, feat:, chore:, docs:, test:, refactor:, perf:, ci:, build:, revert:, release:"
-              echo "Also supports scoped format: fix(deps):, feat(ios):, etc."
               exit 1
               ;;
           esac
@@ -49,13 +50,56 @@ jobs:
             exit 1
           fi
 
-          # For release PRs, require semver version in title
+          # For release PRs, validate version consistency across all files
           if [[ $BASE_PREFIX == "release" ]]; then
-            if [[ ! $PR_TITLE =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            VERSION=$(echo "$PR_TITLE" | grep -oP '\d+\.\d+\.\d+')
+            if [ -z "$VERSION" ]; then
               echo "❌ Release PR title must include a semver version (e.g., release: 1.1.0)"
-              echo "Current title: $PR_TITLE"
               exit 1
             fi
+
+            echo "Checking version $VERSION across all files..."
+            ERRORS=""
+
+            # package.json
+            PKG_VERSION=$(node -p "require('./package.json').version")
+            if [ "$PKG_VERSION" != "$VERSION" ]; then
+              ERRORS="$ERRORS\n  - package.json: found $PKG_VERSION"
+            fi
+
+            # iOS: AutomaticProperties.swift
+            if ! grep -q "return \"$VERSION\"" ios/AutomaticProperties.swift; then
+              FOUND=$(grep -oP 'return "\K[0-9]+\.[0-9]+\.[0-9]+' ios/AutomaticProperties.swift || echo "not found")
+              ERRORS="$ERRORS\n  - ios/AutomaticProperties.swift: found $FOUND"
+            fi
+
+            # iOS: Info.plist
+            if ! grep -q "<string>$VERSION</string>" ios/Info.plist; then
+              FOUND=$(grep -oP '<string>\K[0-9]+\.[0-9]+\.[0-9]+(?=</string>)' ios/Info.plist || echo "not found")
+              ERRORS="$ERRORS\n  - ios/Info.plist: found $FOUND"
+            fi
+
+            # iOS: OursPrivacy-swift.podspec
+            if ! grep -q "s.version = '$VERSION'" ios/OursPrivacy-swift.podspec; then
+              FOUND=$(grep -oP "s\.version = '\K[0-9]+\.[0-9]+\.[0-9]+" ios/OursPrivacy-swift.podspec || echo "not found")
+              ERRORS="$ERRORS\n  - ios/OursPrivacy-swift.podspec: found $FOUND"
+            fi
+
+            # Android: build.gradle
+            if ! grep -q "versionName \"$VERSION\"" android/build.gradle; then
+              FOUND=$(grep -oP 'versionName "\K[^"]+' android/build.gradle || echo "not found")
+              ERRORS="$ERRORS\n  - android/build.gradle: found $FOUND"
+            fi
+
+            if [ -n "$ERRORS" ]; then
+              echo "❌ Version mismatch! PR title says $VERSION but these files don't match:"
+              echo -e "$ERRORS"
+              echo ""
+              echo "All version files must be updated to $VERSION before merging."
+              exit 1
+            fi
+
+            echo "✅ Version $VERSION is consistent across all files"
           fi
 
           echo "✅ PR title format is valid"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -11,6 +11,9 @@ on:
         description: "Version to publish (e.g., 1.1.0)"
         required: true
 
+permissions:
+  contents: write
+
 jobs:
   publish:
     name: Publish to npm
@@ -21,15 +24,13 @@ jobs:
        startsWith(github.event.pull_request.title, 'release:'))
     steps:
       - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org
 
-      - name: Extract version from PR title or input
+      - name: Extract version
         id: version
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
@@ -40,43 +41,20 @@ jobs:
           fi
 
           if [ -z "$VERSION" ]; then
-            echo "❌ Could not extract version"
+            echo "Could not extract version"
+            exit 1
+          fi
+
+          # Verify package.json matches the release version
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$PKG_VERSION" != "$VERSION" ]; then
+            echo "package.json version ($PKG_VERSION) does not match release version ($VERSION)"
+            echo "The PR must include the version bump in package.json"
             exit 1
           fi
 
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Publishing version: $VERSION"
-
-      - name: Bump version everywhere
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-
-          # package.json + package-lock.json
-          npm version "$VERSION" --no-git-tag-version
-
-          # iOS: AutomaticProperties.swift (SDK version sent in events)
-          sed -i 's/return "[0-9]*\.[0-9]*\.[0-9]*"/return "'"$VERSION"'"/' \
-            ios/AutomaticProperties.swift
-
-          # iOS: Info.plist (bundle version)
-          sed -i 's/<string>[0-9]*\.[0-9]*\.[0-9]*<\/string>/<string>'"$VERSION"'<\/string>/' \
-            ios/Info.plist
-
-          # iOS: OursPrivacy-swift.podspec
-          sed -i "s/s\.version = '[0-9]*\.[0-9]*\.[0-9]*'/s.version = '$VERSION'/" \
-            ios/OursPrivacy-swift.podspec
-
-          # Android: build.gradle versionName
-          sed -i 's/versionName "[0-9]*\.[0-9]*[^"]*"/versionName "'"$VERSION"'"/' \
-            android/build.gradle
-
-      - name: Commit version bump
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
-          git diff --cached --quiet || git commit -m "chore: bump version to ${{ steps.version.outputs.version }}"
-          git push
 
       - run: npm ci
 
@@ -84,18 +62,19 @@ jobs:
 
       - run: npx tsc --noEmit
 
-      - name: Publish
+      - name: Publish to npm
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create git tag and GitHub release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="v${{ steps.version.outputs.version }}"
           git tag "$VERSION"
           git push origin "$VERSION"
+
           gh release create "$VERSION" \
             --title "$VERSION" \
             --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,7 +24,7 @@ android {
         minSdkVersion 24
         targetSdkVersion 34
         versionCode 1
-        versionName "1.0"
+        versionName "1.1.0"
     }
     lintOptions {
         abortOnError true

--- a/ios/AutomaticProperties.swift
+++ b/ios/AutomaticProperties.swift
@@ -158,7 +158,7 @@ class AutomaticProperties {
     }
 
     class func libVersion() -> String {
-        return "1.0.0"
+        return "1.1.0"
     }
 
 }

--- a/ios/Info.plist
+++ b/ios/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>1.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/ios/OursPrivacy-swift.podspec
+++ b/ios/OursPrivacy-swift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'OursPrivacy-swift'
-  s.version = '1.0.0'
+  s.version = '1.1.0'
   s.module_name = 'OursPrivacy'
   s.license = 'Apache License, Version 2.0'
   s.summary = 'Ours Privacy tracking library for iOS (Swift)'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oursprivacy/react-native",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oursprivacy/react-native",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oursprivacy/react-native",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Official React Native Tracking Library for OursPrivacy Analytics",
   "main": "index.js",
   "types": "index.d.ts",
@@ -58,7 +58,11 @@
     "verbose": true,
     "haste": {
       "defaultPlatform": "ios",
-      "platforms": ["android", "ios", "native"]
+      "platforms": [
+        "android",
+        "ios",
+        "native"
+      ]
     },
     "transform": {
       "^.+\\.(js|ts|tsx)$": "babel-jest"


### PR DESCRIPTION
## Release 1.1.0

### What's New
- Remove People/Groups/Profile features (Mixpanel-specific, not planned)
- Replace all Mixpanel naming (`$mp_*` → `$op_*`, `mp_lib` → `op_lib`)
- Fix payload structure: session metadata inside `eventProperties`
- Package size: **3.7MB → 686KB**
- Dependencies: `react`/`react-native` properly in peerDependencies
- CI/CD: test + typecheck + PR validation + auto-publish on merge
- Rewritten README and public docs

### Version Bumps
- `package.json` → 1.1.0
- `ios/AutomaticProperties.swift` → 1.1.0
- `ios/Info.plist` → 1.1.0
- `ios/OursPrivacy-swift.podspec` → 1.1.0
- `android/build.gradle` → 1.1.0

### Test Plan
- [x] 69/69 tests passing
- [x] Type check passes
- [x] PR title validation checks version consistency across all files
- [ ] Merging triggers publish to npm + git tag + GitHub release