### PR TITLE
release: 1.2.0

### DIFF
--- a/Demo/App.tsx
+++ b/Demo/App.tsx
@@ -1,15 +1,11 @@
 /**
- * Sample React Native App
- * https://github.com/facebook/react-native
- *
- * @format
+ * Ours Privacy React Native SDK Demo
  */
 
 import React from 'react';
 import type {PropsWithChildren} from 'react';
 import {
   Button,
-  NativeModules,
   ScrollView,
   StatusBar,
   StyleSheet,
@@ -20,54 +16,84 @@ import {
 
 import {
   Colors,
-  DebugInstructions,
   Header,
-  LearnMoreLinks,
-  ReloadInstructions,
 } from 'react-native/Libraries/NewAppScreen';
 
 import { OURSPRIVACY_TOKEN } from '@env';
 import { OursPrivacy } from '@oursprivacy/react-native';
 
-type SectionProps = PropsWithChildren<{
-  title: string;
-}>;
+type SectionProps = PropsWithChildren<{ title: string }>;
 
-let opInstance: OursPrivacy
-async function getOursPrivacy() {
-  if (!opInstance) {
-    opInstance = await OursPrivacy.init(OURSPRIVACY_TOKEN, false, false)
-    opInstance.setLoggingEnabled(true)
-  }
-  return opInstance
+function Section({ children, title }: SectionProps): React.JSX.Element {
+  const isDarkMode = useColorScheme() === 'dark';
+  return (
+    <View style={styles.sectionContainer}>
+      <Text style={[styles.sectionTitle, { color: isDarkMode ? Colors.white : Colors.black }]}>
+        {title}
+      </Text>
+      <Text style={[styles.sectionDescription, { color: isDarkMode ? Colors.light : Colors.dark }]}>
+        {children}
+      </Text>
+    </View>
+  );
 }
 
-async function track(event: string) {
-  try {
-    const op = await getOursPrivacy();
-    const distinctId = await op.getDistinctId();
-    const deviceId = await op.getDeviceId();
-    console.log('[OursPrivacy] distinctId:', distinctId);
-    console.log('[OursPrivacy] deviceId:', deviceId);
-    await op.identify(distinctId);
-    const props = { distinctId };
-    console.log('[OursPrivacy] track:', event, 'props:', JSON.stringify(props));
-    op.track(event, props);
-    op.flush();
-    console.log('[OursPrivacy] flushed');
-  } catch (err) {
-    console.error('[OursPrivacy] Error:', err);
-  }
-}
+// Initialize SDK once using instance pattern
+const oursprivacy = new OursPrivacy(OURSPRIVACY_TOKEN, false, false);
+
+oursprivacy.init(false, {
+  default_event_properties: { demo_app: true },
+  default_user_custom_properties: { test_user: true },
+}).then(() => {
+  oursprivacy.setLoggingEnabled(true);
+  console.log('[OursPrivacy] initialized. visitor_id:', oursprivacy.getVisitorId());
+});
 
 function App(): React.JSX.Element {
   const isDarkMode = useColorScheme() === 'dark';
+  const backgroundStyle = { backgroundColor: isDarkMode ? Colors.darker : Colors.lighter };
+  const safePadding = '5%';
 
-  const backgroundStyle = {
-    backgroundColor: isDarkMode ? Colors.darker : Colors.lighter,
+  const handleTrack = () => {
+    console.log('[OursPrivacy] visitor_id:', oursprivacy.getVisitorId());
+    oursprivacy.track('button_pressed', { button: 'Track Green' });
+    oursprivacy.flush();
+    console.log('[OursPrivacy] tracked + flushed');
   };
 
-  const safePadding = '5%';
+  const handleIdentify = () => {
+    oursprivacy.identify('demo-user@example.com', {
+      email: 'demo-user@example.com',
+      external_id: 'demo-user-123',
+      custom_properties: { plan: 'demo' },
+    });
+    oursprivacy.flush();
+    console.log('[OursPrivacy] identified + flushed');
+  };
+
+  const handleUpdateDefaults = () => {
+    oursprivacy.updateDefaultEventProperties({ last_action: 'update_defaults' });
+    oursprivacy.updateDefaultUserConsentProperties({ marketing: true, analytics: true });
+    oursprivacy.track('defaults_updated');
+    oursprivacy.flush();
+    console.log('[OursPrivacy] defaults updated + tracked + flushed');
+  };
+
+  const handleOptOut = () => {
+    oursprivacy.optOutTracking();
+    console.log('[OursPrivacy] opted out');
+  };
+
+  const handleOptIn = () => {
+    oursprivacy.optInTracking();
+    oursprivacy.flush();
+    console.log('[OursPrivacy] opted in + flushed ($opt_in event sent)');
+  };
+
+  const handleReset = () => {
+    oursprivacy.reset();
+    console.log('[OursPrivacy] reset. new visitor_id:', oursprivacy.getVisitorId());
+  };
 
   return (
     <View style={backgroundStyle}>
@@ -75,23 +101,41 @@ function App(): React.JSX.Element {
         barStyle={isDarkMode ? 'light-content' : 'dark-content'}
         backgroundColor={backgroundStyle.backgroundColor}
       />
-      <ScrollView
-        style={backgroundStyle}>
-        <View style={{paddingRight: safePadding}}>
-          <Header/>
+      <ScrollView style={backgroundStyle}>
+        <View style={{ paddingRight: safePadding }}>
+          <Header />
         </View>
-        <View
-          style={{
-            backgroundColor: isDarkMode ? Colors.black : Colors.white,
-            paddingHorizontal: safePadding,
-            paddingBottom: safePadding,
-          }}>
-            <Button
-              onPress={() => track("Green")}
-              title="Track Green"
-              color="#841584"
-              accessibilityLabel="Track Green Test"
-            />
+        <View style={{
+          backgroundColor: isDarkMode ? Colors.black : Colors.white,
+          paddingHorizontal: safePadding,
+          paddingBottom: safePadding,
+          gap: 12,
+        }}>
+          <Section title="Track Event">
+            Calls track('button_pressed') + flush(). Check console for visitor_id.
+          </Section>
+          <Button onPress={handleTrack} title="Track Event" color="#841584" />
+
+          <Section title="Identify">
+            Calls identify with email, external_id, and custom_properties.
+          </Section>
+          <Button onPress={handleIdentify} title="Identify User" color="#1a73e8" />
+
+          <Section title="Update Default Properties">
+            Updates default event + consent properties, then tracks an event.
+          </Section>
+          <Button onPress={handleUpdateDefaults} title="Update Defaults + Track" color="#0f9d58" />
+
+          <Section title="Privacy Controls">
+            Opt out stops all tracking. Opt in resumes and sends $opt_in event.
+          </Section>
+          <Button onPress={handleOptOut} title="Opt Out" color="#ea4335" />
+          <Button onPress={handleOptIn} title="Opt In" color="#0f9d58" />
+
+          <Section title="Reset">
+            Clears identity and default properties. Generates new visitor_id.
+          </Section>
+          <Button onPress={handleReset} title="Reset" color="#f4a637" />
         </View>
       </ScrollView>
     </View>
@@ -100,20 +144,17 @@ function App(): React.JSX.Element {
 
 const styles = StyleSheet.create({
   sectionContainer: {
-    marginTop: 32,
-    paddingHorizontal: 24,
+    marginTop: 16,
+    paddingHorizontal: 0,
   },
   sectionTitle: {
-    fontSize: 24,
+    fontSize: 16,
     fontWeight: '600',
   },
   sectionDescription: {
-    marginTop: 8,
-    fontSize: 18,
+    marginTop: 4,
+    fontSize: 13,
     fontWeight: '400',
-  },
-  highlight: {
-    fontWeight: '700',
   },
 });
 

--- a/README.md
+++ b/README.md
@@ -121,17 +121,11 @@ export default function App() {
 
 ## Expo / React Native Web
 
-The SDK falls back to a pure JavaScript implementation when native modules aren't available.
+The SDK uses a JavaScript implementation backed by `@react-native-async-storage/async-storage`. No native module setup is required.
 
 ```js
-const op = new OursPrivacy('YOUR_API_TOKEN', false, false);
+const op = new OursPrivacy('YOUR_API_TOKEN', false);
 await op.init();
-```
-
-This requires `@react-native-async-storage/async-storage`:
-
-```bash
-npm install @react-native-async-storage/async-storage
 ```
 
 You can also provide a custom storage implementation:
@@ -149,15 +143,14 @@ The storage adapter must implement `getItem`, `setItem`, and `removeItem` (same 
 
 ### Initialization
 
-#### `new OursPrivacy(token, useNative?, storage?)`
+#### `new OursPrivacy(token, storage?)`
 
 Creates an OursPrivacy instance. You must call `.init()` before tracking.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `token` | `string` | Yes | Your project token |
-| `useNative` | `boolean` | No | Use native iOS/Android modules (default: `true`). Set to `false` for Expo/web |
-| `storage` | `OursPrivacyAsyncStorage` | No | Custom storage adapter (only used when `useNative` is `false`) |
+| `storage` | `OursPrivacyAsyncStorage` | No | Custom AsyncStorage adapter |
 
 **Returns:** `OursPrivacy` instance (call `.init()` to complete setup)
 
@@ -181,7 +174,7 @@ Initializes the SDK. Must be called before tracking.
 | Field | Type | Description |
 |-------|------|-------------|
 | `serverURL` | `string` | Override the default API endpoint |
-| `user_id` | `string` | Pre-set a visitor ID; sets `is_manually_set_id: true` on all events |
+| `visitor_id` | `string` | Pre-set the visitor ID; sets `is_manually_set_id: true` on all events |
 | `default_event_properties` | `object` | Properties merged into `eventProperties` on every `track()` call |
 | `default_user_custom_properties` | `object` | Properties merged into `userProperties.custom_properties` on every event |
 | `default_user_consent_properties` | `object` | Properties merged into `userProperties.consent` on every event |
@@ -195,7 +188,7 @@ await op.init();
 // With options
 await op.init(false, {
   serverURL: 'https://api-eu.oursprivacy.com',
-  user_id: 'pre-known-id',
+  visitor_id: 'pre-known-id',
   default_event_properties: { platform: 'mobile', app_version: '2.0.0' },
   default_user_custom_properties: { tier: 'pro' },
   default_user_consent_properties: { marketing: true },
@@ -223,13 +216,13 @@ op.track('Page View', { page: '/home', referrer: 'google' });
 
 ---
 
-#### `op.identify(distinctId, userProperties?)`
+#### `op.identify(id, userProperties?)`
 
-Associate all future `track()` calls with the given user ID. Call this after a user logs in.
+Associate all future `track()` calls with the given user identity. Call this after a user logs in.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `distinctId` | `string` | Yes | A string uniquely identifying this user |
+| `id` | `string` | Yes | The user's known identifier (e.g. email or external ID) |
 | `userProperties` | `OursPrivacyUserProperties` | No | User properties to attach |
 
 **`OursPrivacyUserProperties` shape:**
@@ -430,7 +423,7 @@ op.setFlushBatchSize(25);
 
 #### `op.getVisitorId()`
 
-Returns the stable visitor UUID for this device. This is the preferred method for retrieving a user identifier — it returns a clean UUID with no prefix.
+Returns the stable visitor UUID for this install. Synchronous. No prefix.
 
 **Returns:** `string | null`
 
@@ -528,10 +521,10 @@ The SDK sends a JSON body to `POST /api/v1/track`. Understanding this structure 
 | Field | Description |
 |-------|-------------|
 | `token` | Your project token |
-| `is_manually_set_id` | `true` when `user_id` was passed in `init()` options |
+| `is_manually_set_id` | `true` when `visitor_id` was passed in `init()` options |
 | `data` | Array of event objects in this batch |
 | `event` | Event name |
-| `visitor_id` | Stable device UUID (no prefix) |
+| `visitor_id` | Stable visitor UUID for this install (no prefix) |
 | `distinct_id` | Per-event UUID, same as `visitor_id` for anonymous users |
 | `eventProperties` | Properties from `track()` merged with default event properties |
 | `userProperties.custom_properties` | From `identify()` and `updateDefaultUserCustomProperties()` |

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://img.shields.io/npm/v/@oursprivacy/react-native.svg)](https://www.npmjs.com/package/@oursprivacy/react-native)
 [![GitHub](https://img.shields.io/badge/GitHub-repo-blue)](https://github.com/with-ours/ours-privacy-react-native)
 
-Privacy-first analytics for React Native. Wraps native iOS and Android SDKs with a pure JavaScript fallback for Expo and web.
+Privacy-first analytics for React Native.
 
 - [npm](https://www.npmjs.com/package/@oursprivacy/react-native)
 - [GitHub](https://github.com/with-ours/ours-privacy-react-native)
@@ -15,7 +15,6 @@ Privacy-first analytics for React Native. Wraps native iOS and Android SDKs with
 
 - [Quick Start](#quick-start)
 - [Complete Example](#complete-example)
-- [Expo / React Native Web](#expo--react-native-web)
 - [API Reference](#api-reference)
   - [Initialization](#initialization)
   - [Core Tracking](#core-tracking)
@@ -36,12 +35,6 @@ Privacy-first analytics for React Native. Wraps native iOS and Android SDKs with
 
 ```bash
 npm install @oursprivacy/react-native
-```
-
-For iOS, run `pod install` in your `ios/` directory:
-
-```bash
-cd ios && pod install
 ```
 
 ### 2. Initialize
@@ -119,43 +112,25 @@ export default function App() {
 
 ---
 
-## Expo / React Native Web
-
-The SDK uses a JavaScript implementation backed by `@react-native-async-storage/async-storage`. No native module setup is required.
-
-```js
-const op = new OursPrivacy('YOUR_API_TOKEN', false);
-await op.init();
-```
-
-You can also provide a custom storage implementation:
-
-```js
-const op = new OursPrivacy('YOUR_API_TOKEN', false, false, MyCustomStorage);
-await op.init();
-```
-
-The storage adapter must implement `getItem`, `setItem`, and `removeItem` (same interface as AsyncStorage).
-
----
-
 ## API Reference
 
 ### Initialization
 
-#### `new OursPrivacy(token, storage?)`
+#### `new OursPrivacy(token, trackAutomaticEvents, useNative?, storage?)`
 
 Creates an OursPrivacy instance. You must call `.init()` before tracking.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `token` | `string` | Yes | Your project token |
+| `trackAutomaticEvents` | `boolean` | Yes | Whether to track automatic events |
+| `useNative` | `boolean` | No | Ignored — SDK always uses the JavaScript implementation |
 | `storage` | `OursPrivacyAsyncStorage` | No | Custom AsyncStorage adapter |
 
 **Returns:** `OursPrivacy` instance (call `.init()` to complete setup)
 
 ```js
-const op = new OursPrivacy('YOUR_API_TOKEN');
+const op = new OursPrivacy('YOUR_API_TOKEN', false);
 ```
 
 ---
@@ -173,7 +148,6 @@ Initializes the SDK. Must be called before tracking.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `serverURL` | `string` | Override the default API endpoint |
 | `visitor_id` | `string` | Pre-set the visitor ID; sets `is_manually_set_id: true` on all events |
 | `default_event_properties` | `object` | Properties merged into `eventProperties` on every `track()` call |
 | `default_user_custom_properties` | `object` | Properties merged into `userProperties.custom_properties` on every event |
@@ -187,7 +161,6 @@ await op.init();
 
 // With options
 await op.init(false, {
-  serverURL: 'https://api-eu.oursprivacy.com',
   visitor_id: 'pre-known-id',
   default_event_properties: { platform: 'mobile', app_version: '2.0.0' },
   default_user_custom_properties: { tier: 'pro' },
@@ -356,18 +329,13 @@ op.updateDefaultUserConsentProperties({ marketing: true });
 
 #### `op.setServerURL(serverURL)`
 
-Override the API endpoint after initialization. Use this to route to Ours Privacy's EU servers or a proxy.
+Override the API endpoint after initialization.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `serverURL` | `string` | Yes | Base URL for API requests |
 
 **Returns:** `void`
-
-```js
-// EU data residency
-op.setServerURL('https://api-eu.oursprivacy.com');
-```
 
 ---
 
@@ -608,17 +576,6 @@ Events are batched and sent every 60 seconds or when the app backgrounds. Call `
 - iOS 10+
 - Android API 21+
 - Expo (JavaScript mode)
-
-**How do I route data to EU servers?**
-
-Pass `serverURL` in the `init` options or call `setServerURL()` after initialization:
-
-```js
-await op.init(false, { serverURL: 'https://api-eu.oursprivacy.com' });
-
-// or
-op.setServerURL('https://api-eu.oursprivacy.com');
-```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,29 @@ Privacy-first analytics for React Native. Wraps native iOS and Android SDKs with
 - [GitHub](https://github.com/with-ours/ours-privacy-react-native)
 - [Docs](https://docs.oursprivacy.com/docs/react-native-sdk)
 
+---
+
+## Table of Contents
+
+- [Quick Start](#quick-start)
+- [Complete Example](#complete-example)
+- [Expo / React Native Web](#expo--react-native-web)
+- [API Reference](#api-reference)
+  - [Initialization](#initialization)
+  - [Core Tracking](#core-tracking)
+  - [Default Properties](#default-properties)
+  - [Configuration](#configuration)
+  - [Identity](#identity)
+  - [Timing](#timing)
+  - [Privacy Controls](#privacy-controls)
+  - [Deprecated Methods](#deprecated-methods)
+- [Payload Structure](#payload-structure)
+- [Migration from Mixpanel](#migration-from-mixpanel)
+- [FAQ](#faq)
+- [Support](#support)
+
+---
+
 ## Quick Start
 
 ### 1. Install
@@ -28,10 +51,11 @@ cd ios && pod install
 ```js
 import { OursPrivacy } from '@oursprivacy/react-native';
 
-const op = await OursPrivacy.init('YOUR_API_TOKEN', false);
+const op = new OursPrivacy('YOUR_API_TOKEN', false);
+await op.init();
 ```
 
-That's it. The SDK connects to `https://api.oursprivacy.com/api/v1` by default — no endpoint configuration needed.
+That's it. The SDK connects to `https://cdn.oursprivacy.com` by default — no endpoint configuration needed.
 
 ### 3. Track Events
 
@@ -45,7 +69,10 @@ op.track('Purchase', { value: 49.99, currency: 'USD' });
 After login, link events to a user:
 
 ```js
-await op.identify('user-123');
+await op.identify('user-123', {
+  email: 'user@example.com',
+  first_name: 'Jane',
+});
 ```
 
 ### 5. Flush
@@ -56,6 +83,8 @@ Events are batched and sent every 60 seconds or when the app backgrounds. To sen
 op.flush();
 ```
 
+---
+
 ## Complete Example
 
 ```js
@@ -64,9 +93,13 @@ import { Button, SafeAreaView } from 'react-native';
 import { OursPrivacy } from '@oursprivacy/react-native';
 
 let op;
-async function getOursPrivacy() {
+
+async function getClient() {
   if (!op) {
-    op = await OursPrivacy.init('YOUR_API_TOKEN', false);
+    op = new OursPrivacy('YOUR_API_TOKEN', false);
+    await op.init(false, {
+      default_event_properties: { app_version: '2.0.0' },
+    });
   }
   return op;
 }
@@ -77,7 +110,7 @@ export default function App() {
       <Button
         title="Track Event"
         onPress={async () => {
-          const client = await getOursPrivacy();
+          const client = await getClient();
           client.track('Button Pressed', { screen: 'Home' });
         }}
       />
@@ -86,14 +119,14 @@ export default function App() {
 }
 ```
 
+---
+
 ## Expo / React Native Web
 
 The SDK falls back to a pure JavaScript implementation when native modules aren't available.
 
 ```js
-const trackAutomaticEvents = false;
-const useNative = false;
-const op = new OursPrivacy('YOUR_API_TOKEN', trackAutomaticEvents, useNative);
+const op = new OursPrivacy('YOUR_API_TOKEN', false, false);
 await op.init();
 ```
 
@@ -110,58 +143,663 @@ const op = new OursPrivacy('YOUR_API_TOKEN', false, false, MyCustomStorage);
 await op.init();
 ```
 
-The storage must implement `getItem`, `setItem`, and `removeItem` (same interface as AsyncStorage).
+The storage adapter must implement `getItem`, `setItem`, and `removeItem` (same interface as AsyncStorage).
+
+---
 
 ## API Reference
 
 ### Initialization
 
-| Method | Description |
-|--------|-------------|
-| `OursPrivacy.init(token, trackAutomaticEvents)` | Initialize and return an instance (recommended) |
-| `new OursPrivacy(token, trackAutomaticEvents, useNative?, storage?)` | Constructor (call `.init()` after) |
+#### `new OursPrivacy(token, useNative?, storage?)`
 
-### Core Methods
+Creates an OursPrivacy instance. You must call `.init()` before tracking.
 
-| Method | Description |
-|--------|-------------|
-| `track(event, properties?)` | Track an event with optional properties |
-| `identify(distinctId, userProperties?)` | Link events to a user ID |
-| `flush()` | Send queued events immediately |
-| `reset()` | Clear stored user identity |
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `token` | `string` | Yes | Your project token |
+| `useNative` | `boolean` | No | Use native iOS/Android modules (default: `true`). Set to `false` for Expo/web |
+| `storage` | `OursPrivacyAsyncStorage` | No | Custom storage adapter (only used when `useNative` is `false`) |
+
+**Returns:** `OursPrivacy` instance (call `.init()` to complete setup)
+
+```js
+const op = new OursPrivacy('YOUR_API_TOKEN');
+```
+
+---
+
+#### `op.init(optOutTrackingDefault?, options?)`
+
+Initializes the SDK. Must be called before tracking.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `optOutTrackingDefault` | `boolean` | No | If `true`, tracking is opted out by default (default: `false`) |
+| `options` | `OursPrivacyInitOptions` | No | Additional initialization options (see below) |
+
+**`OursPrivacyInitOptions` shape:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `serverURL` | `string` | Override the default API endpoint |
+| `user_id` | `string` | Pre-set a visitor ID; sets `is_manually_set_id: true` on all events |
+| `default_event_properties` | `object` | Properties merged into `eventProperties` on every `track()` call |
+| `default_user_custom_properties` | `object` | Properties merged into `userProperties.custom_properties` on every event |
+| `default_user_consent_properties` | `object` | Properties merged into `userProperties.consent` on every event |
+
+**Returns:** `Promise<void>`
+
+```js
+// Minimal init
+await op.init();
+
+// With options
+await op.init(false, {
+  serverURL: 'https://api-eu.oursprivacy.com',
+  user_id: 'pre-known-id',
+  default_event_properties: { platform: 'mobile', app_version: '2.0.0' },
+  default_user_custom_properties: { tier: 'pro' },
+  default_user_consent_properties: { marketing: true },
+});
+```
+
+---
+
+### Core Tracking
+
+#### `op.track(eventName, properties?)`
+
+Track an event with optional properties.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `eventName` | `string` | Yes | Name of the event |
+| `properties` | `object` | No | Key/value pairs to attach to the event |
+
+**Returns:** `void`
+
+```js
+op.track('Page View', { page: '/home', referrer: 'google' });
+```
+
+---
+
+#### `op.identify(distinctId, userProperties?)`
+
+Associate all future `track()` calls with the given user ID. Call this after a user logs in.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `distinctId` | `string` | Yes | A string uniquely identifying this user |
+| `userProperties` | `OursPrivacyUserProperties` | No | User properties to attach |
+
+**`OursPrivacyUserProperties` shape:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `email` | `string` | User's email address |
+| `external_id` | `string` | ID from your own system |
+| `phone_number` | `string` | User's phone number |
+| `first_name` | `string` | First name |
+| `last_name` | `string` | Last name |
+| `custom_properties` | `object` | Arbitrary custom user attributes |
+| `consent` | `object` | Consent flags (e.g. `{ marketing: true }`) |
+
+**Returns:** `Promise<void>`
+
+```js
+await op.identify('user-123', {
+  email: 'jane@example.com',
+  external_id: 'db-user-456',
+  first_name: 'Jane',
+  custom_properties: { tier: 'pro' },
+  consent: { marketing: true },
+});
+```
+
+---
+
+#### `op.flush()`
+
+Push all queued events to the server immediately. Useful before app close or logout.
+
+**Returns:** `void`
+
+```js
+op.flush();
+```
+
+---
+
+#### `op.reset()`
+
+Clear the current user identity and all default properties. Generates a new random visitor ID. Call this when a user logs out.
+
+**Returns:** `void`
+
+```js
+op.reset();
+```
+
+---
+
+### Default Properties
+
+Default properties are automatically merged into every event the SDK sends. They are the primary way to attach persistent, per-user or per-session context without repeating it on every `track()` call.
+
+These methods can be called at init time via `options`, or at any point afterwards.
+
+---
+
+#### `op.updateDefaultEventProperties(properties)`
+
+Merge properties into `eventProperties` on every future `track()` call. Properties are merged shallowly — later calls overwrite earlier ones for the same key.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `properties` | `object` | Yes | Key/value pairs to merge into default event properties |
+
+**Returns:** `void`
+
+```js
+// At init time:
+await op.init(false, {
+  default_event_properties: { app_version: '2.0.0', environment: 'production' },
+});
+
+// Or post-init (e.g. after fetching user data):
+op.updateDefaultEventProperties({ experiment_group: 'variant_b' });
+
+// Every subsequent track() will include these automatically:
+op.track('Button Pressed'); // eventProperties includes app_version, environment, experiment_group
+```
+
+---
+
+#### `op.updateDefaultUserCustomProperties(properties)`
+
+Merge properties into `userProperties.custom_properties` on every future event. Useful for attaching user attributes that should travel with every event.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `properties` | `object` | Yes | Key/value pairs to merge into default user custom properties |
+
+**Returns:** `void`
+
+```js
+// At init time:
+await op.init(false, {
+  default_user_custom_properties: { tier: 'pro' },
+});
+
+// Or post-init (e.g. after subscription status loads):
+op.updateDefaultUserCustomProperties({ tier: 'enterprise', seats: 50 });
+```
+
+---
+
+#### `op.updateDefaultUserConsentProperties(properties)`
+
+Merge properties into `userProperties.consent` on every future event. Use this to send the user's consent state alongside all analytics events.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `properties` | `object` | Yes | Key/value pairs to merge into default user consent properties |
+
+**Returns:** `void`
+
+```js
+// At init time:
+await op.init(false, {
+  default_user_consent_properties: { marketing: false, analytics: true },
+});
+
+// Or when the user updates their preferences:
+op.updateDefaultUserConsentProperties({ marketing: true });
+```
+
+---
 
 ### Configuration
 
-| Method | Description |
-|--------|-------------|
-| `setServerURL(url)` | Override API endpoint |
-| `setLoggingEnabled(enabled)` | Enable/disable debug logging |
-| `setFlushOnBackground(enabled)` | Flush when app backgrounds (default: true) |
-| `setFlushBatchSize(size)` | Set batch size for flushing |
-| `setUseIpAddressForGeolocation(enabled)` | Use IP for geolocation |
+#### `op.setServerURL(serverURL)`
 
-### Privacy
+Override the API endpoint after initialization. Use this to route to Ours Privacy's EU servers or a proxy.
 
-| Method | Description |
-|--------|-------------|
-| `optOutTracking()` | Stop all tracking |
-| `optInTracking()` | Resume tracking |
-| `hasOptedOutTracking()` | Check opt-out state |
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `serverURL` | `string` | Yes | Base URL for API requests |
+
+**Returns:** `void`
+
+```js
+// EU data residency
+op.setServerURL('https://api-eu.oursprivacy.com');
+```
+
+---
+
+#### `op.setLoggingEnabled(loggingEnabled)`
+
+Enable or disable debug logging. All logging is disabled by default.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `loggingEnabled` | `boolean` | Yes | Whether to enable SDK logging |
+
+**Returns:** `void`
+
+```js
+op.setLoggingEnabled(true);
+```
+
+---
+
+#### `op.setFlushOnBackground(flushOnBackground)`
+
+Control whether the SDK flushes events when the app enters the background. Enabled by default. **iOS only** — calling this on Android is a no-op with a console warning.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `flushOnBackground` | `boolean` | Yes | Whether to flush on app background |
+
+**Returns:** `void`
+
+```js
+op.setFlushOnBackground(false);
+```
+
+---
+
+#### `op.setUseIpAddressForGeolocation(useIpAddressForGeolocation)`
+
+Control whether the client IP address is sent with events for geolocation. Enabled by default.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `useIpAddressForGeolocation` | `boolean` | Yes | Whether to include IP for geolocation |
+
+**Returns:** `void`
+
+```js
+op.setUseIpAddressForGeolocation(false);
+```
+
+---
+
+#### `op.setFlushBatchSize(flushBatchSize)`
+
+Set the maximum number of events sent in a single network request. Maximum value is 50; values above 50 are clamped to 50.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `flushBatchSize` | `number` | Yes | Number of events per batch (max 50) |
+
+**Returns:** `void`
+
+```js
+op.setFlushBatchSize(25);
+```
+
+---
 
 ### Identity
 
-| Method | Description |
-|--------|-------------|
-| `alias(alias, distinctId)` | Create an alias for a user |
-| `getDistinctId()` | Get current distinct ID |
-| `getDeviceId()` | Get device ID |
+#### `op.getVisitorId()`
+
+Returns the stable visitor UUID for this device. This is the preferred method for retrieving a user identifier — it returns a clean UUID with no prefix.
+
+**Returns:** `string | null`
+
+```js
+const visitorId = op.getVisitorId();
+console.log(visitorId); // e.g. "550e8400-e29b-41d4-a716-446655440000"
+```
+
+---
+
+#### `op.getDistinctId()`
+
+⚠️ **Deprecated** — Use `getVisitorId()` instead.
+
+Returns the current distinct ID. For anonymous users, this is the same as the visitor ID.
+
+**Returns:** `Promise<string>`
+
+```js
+const id = await op.getDistinctId();
+```
+
+---
+
+#### `op.getDeviceId()`
+
+⚠️ **Deprecated** — Use `getVisitorId()` instead.
+
+Returns the device ID.
+
+**Returns:** `Promise<string>`
+
+```js
+const deviceId = await op.getDeviceId();
+```
+
+---
 
 ### Timing
 
-| Method | Description |
-|--------|-------------|
-| `timeEvent(event)` | Start timing an event |
-| `eventElapsedTime(event)` | Get elapsed time for a timed event |
+#### `op.timeEvent(eventName)`
+
+Begin timing an event. When you later call `track()` with the same event name, the event will include a `$duration` property (in seconds).
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `eventName` | `string` | Yes | Name of the event to time |
+
+**Returns:** `void`
+
+```js
+op.timeEvent('Video Watched');
+
+// ... later:
+op.track('Video Watched', { video_id: 'abc123' }); // includes $duration
+```
+
+---
+
+#### `op.eventElapsedTime(eventName)`
+
+Get the elapsed time in seconds since `timeEvent()` was called for the given event, without sending the event.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `eventName` | `string` | Yes | Name of the previously timed event |
+
+**Returns:** `Promise<number>` — elapsed seconds
+
+```js
+op.timeEvent('Checkout');
+// ... later:
+const elapsed = await op.eventElapsedTime('Checkout');
+console.log(`Checkout has been open for ${elapsed}s`);
+```
+
+---
+
+### Privacy Controls
+
+#### `op.optOutTracking()`
+
+Stop all tracking immediately. Any queued events that have not been flushed will be discarded. Call `flush()` first if you want to preserve queued events.
+
+**Returns:** `void`
+
+```js
+// Flush first to preserve any pending events
+op.flush();
+op.optOutTracking();
+```
+
+---
+
+#### `op.optInTracking()`
+
+Resume tracking after a previous call to `optOutTracking()`. This also sends an `$opt_in` event to the server.
+
+**Returns:** `void`
+
+```js
+op.optInTracking();
+```
+
+---
+
+#### `op.hasOptedOutTracking()`
+
+Check whether the current user has opted out of tracking.
+
+**Returns:** `Promise<boolean>`
+
+```js
+const hasOptedOut = await op.hasOptedOutTracking();
+if (hasOptedOut) {
+  console.log('User has opted out');
+}
+```
+
+---
+
+### Deprecated Methods
+
+The following methods are kept for backwards compatibility but should not be used in new code.
+
+#### ⚠️ `op.registerSuperProperties(properties)`
+
+**Deprecated** — Use `updateDefaultEventProperties()` instead.
+
+Register properties that will be sent with every future `track()` call.
+
+```js
+// Deprecated
+op.registerSuperProperties({ plan: 'pro' });
+
+// Use instead
+op.updateDefaultEventProperties({ plan: 'pro' });
+```
+
+---
+
+#### ⚠️ `op.registerSuperPropertiesOnce(properties)`
+
+**Deprecated** — Use `updateDefaultEventProperties()` instead.
+
+Register super properties only if those keys have not already been registered.
+
+```js
+// Deprecated
+op.registerSuperPropertiesOnce({ first_open: true });
+```
+
+---
+
+#### ⚠️ `op.getSuperProperties()`
+
+**Deprecated** — Use `updateDefaultEventProperties()` instead.
+
+Returns the currently registered super properties.
+
+**Returns:** `Promise<object>`
+
+```js
+// Deprecated
+const props = await op.getSuperProperties();
+```
+
+---
+
+#### ⚠️ `op.unregisterSuperProperty(propertyName)`
+
+**Deprecated** — Use `updateDefaultEventProperties()` instead.
+
+Remove a single super property so it is no longer sent with future events.
+
+```js
+// Deprecated
+op.unregisterSuperProperty('experiment_group');
+```
+
+---
+
+#### ⚠️ `op.clearSuperProperties()`
+
+**Deprecated** — Use `updateDefaultEventProperties()` instead.
+
+Remove all registered super properties.
+
+```js
+// Deprecated
+op.clearSuperProperties();
+```
+
+---
+
+#### ⚠️ `op.alias(alias, distinctId)`
+
+**Deprecated.** Creates an alias mapping one ID to another.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `alias` | `string` | The new alias identifier |
+| `distinctId` | `string` | The existing distinct ID to map to |
+
+**Returns:** `void`
+
+```js
+// Deprecated
+op.alias('user-123', op.getVisitorId());
+```
+
+---
+
+#### ⚠️ `OursPrivacy.init(token, trackAutomaticEvents, optOutTrackingDefault?)` (static)
+
+**Deprecated** — Use `new OursPrivacy(...).init()` instead.
+
+The static `init` method was the original initialization pattern. It bypasses the JavaScript fallback path and only works with native modules.
+
+```js
+// Deprecated (static form)
+const op = await OursPrivacy.init('YOUR_API_TOKEN', false);
+
+// Use instead (instance form)
+const op = new OursPrivacy('YOUR_API_TOKEN', false);
+await op.init();
+```
+
+---
+
+## Payload Structure
+
+The SDK sends a JSON body to `POST /api/v1/track`. Understanding this structure is useful if you are building a proxy, debugging with a network inspector, or verifying your data in the Ours Privacy dashboard.
+
+```json
+{
+  "token": "your-project-token",
+  "is_manually_set_id": false,
+  "data": [
+    {
+      "event": "Purchase",
+      "visitor_id": "550e8400-e29b-41d4-a716-446655440000",
+      "distinct_id": "550e8400-e29b-41d4-a716-446655440000",
+      "eventProperties": {
+        "price": 99
+      },
+      "userProperties": {
+        "custom_properties": {
+          "tier": "pro"
+        },
+        "consent": {
+          "marketing": true
+        }
+      },
+      "defaultProperties": {
+        "device_type": "mobile",
+        "os_name": "iOS",
+        "os_version": "17.0",
+        "device_vendor": "Apple",
+        "device_model": "iPhone 16 Pro",
+        "screen_width": 390,
+        "screen_height": 844,
+        "version": "1.1.0"
+      }
+    }
+  ]
+}
+```
+
+**Key fields:**
+
+| Field | Description |
+|-------|-------------|
+| `token` | Your project token |
+| `is_manually_set_id` | `true` when `user_id` was passed in `init()` options |
+| `data` | Array of event objects in this batch |
+| `event` | Event name |
+| `visitor_id` | Stable device UUID (no prefix) |
+| `distinct_id` | Per-event UUID, same as `visitor_id` for anonymous users |
+| `eventProperties` | Properties from `track()` merged with default event properties |
+| `userProperties.custom_properties` | From `identify()` and `updateDefaultUserCustomProperties()` |
+| `userProperties.consent` | From `identify()` and `updateDefaultUserConsentProperties()` |
+| `defaultProperties` | Automatically collected device/SDK metadata |
+
+---
+
+## Migration from Mixpanel
+
+This SDK was originally forked from the Mixpanel React Native SDK. If you are migrating from Mixpanel or from an earlier version of this SDK, note the following:
+
+### Removed features
+
+The following Mixpanel-specific features have been removed and are not planned:
+
+- **People / Profiles** — `mixpanel.getPeople()`, `people.set()`, `people.increment()`, etc.
+- **Groups** — `mixpanel.getGroup()`, `setGroup()`, `addGroup()`, etc.
+
+These APIs do not exist in `@oursprivacy/react-native` and will throw if called.
+
+### Renamed package
+
+```bash
+# Remove Mixpanel
+npm uninstall @mixpanel/react-native
+
+# Install Ours Privacy
+npm install @oursprivacy/react-native
+```
+
+```js
+// Before
+import { Mixpanel } from '@mixpanel/react-native';
+const mp = await Mixpanel.init('TOKEN', false);
+
+// After
+import { OursPrivacy } from '@oursprivacy/react-native';
+const op = new OursPrivacy('TOKEN', false);
+await op.init();
+```
+
+### Super properties → Default properties
+
+The `registerSuperProperties` family of methods is deprecated in favor of the new default properties API, which maps directly to the Ours Privacy event schema:
+
+```js
+// Before (Mixpanel-style super properties)
+op.registerSuperProperties({ plan: 'pro', environment: 'production' });
+
+// After (Ours Privacy default event properties)
+op.updateDefaultEventProperties({ plan: 'pro', environment: 'production' });
+
+// New: per-user custom properties sent on every event
+op.updateDefaultUserCustomProperties({ tier: 'enterprise' });
+
+// New: consent state sent on every event
+op.updateDefaultUserConsentProperties({ marketing: true, analytics: true });
+```
+
+### Distinct ID
+
+Mixpanel's distinct ID could include a device-prefix (e.g. `$device:uuid`). Ours Privacy uses a clean UUID with no prefix:
+
+```js
+// Before (may return "$device:uuid" string)
+const id = await op.getDistinctId();
+
+// After (returns clean UUID)
+const id = op.getVisitorId();
+```
+
+---
 
 ## FAQ
 
@@ -179,6 +817,23 @@ Events are batched and sent every 60 seconds or when the app backgrounds. Call `
 - iOS 10+
 - Android API 21+
 - Expo (JavaScript mode)
+
+**How do I route data to EU servers?**
+
+Pass `serverURL` in the `init` options or call `setServerURL()` after initialization:
+
+```js
+await op.init(false, { serverURL: 'https://api-eu.oursprivacy.com' });
+
+// or
+op.setServerURL('https://api-eu.oursprivacy.com');
+```
+
+**What is the difference between `getVisitorId()` and `getDistinctId()`?**
+
+`getVisitorId()` returns a clean UUID with no prefix and is synchronous. `getDistinctId()` is asynchronous and may return a prefixed string on older SDK versions. Use `getVisitorId()` for all new code.
+
+---
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -410,22 +410,6 @@ op.setFlushOnBackground(false);
 
 ---
 
-#### `op.setUseIpAddressForGeolocation(useIpAddressForGeolocation)`
-
-Control whether the client IP address is sent with events for geolocation. Enabled by default.
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `useIpAddressForGeolocation` | `boolean` | Yes | Whether to include IP for geolocation |
-
-**Returns:** `void`
-
-```js
-op.setUseIpAddressForGeolocation(false);
-```
-
----
-
 #### `op.setFlushBatchSize(flushBatchSize)`
 
 Set the maximum number of events sent in a single network request. Maximum value is 50; values above 50 are clamped to 50.

--- a/README.md
+++ b/README.md
@@ -22,9 +22,7 @@ Privacy-first analytics for React Native. Wraps native iOS and Android SDKs with
   - [Default Properties](#default-properties)
   - [Configuration](#configuration)
   - [Identity](#identity)
-  - [Timing](#timing)
   - [Privacy Controls](#privacy-controls)
-  - [Deprecated Methods](#deprecated-methods)
 - [Payload Structure](#payload-structure)
 - [Migration from Mixpanel](#migration-from-mixpanel)
 - [FAQ](#faq)
@@ -459,74 +457,6 @@ console.log(visitorId); // e.g. "550e8400-e29b-41d4-a716-446655440000"
 
 ---
 
-#### `op.getDistinctId()`
-
-⚠️ **Deprecated** — Use `getVisitorId()` instead.
-
-Returns the current distinct ID. For anonymous users, this is the same as the visitor ID.
-
-**Returns:** `Promise<string>`
-
-```js
-const id = await op.getDistinctId();
-```
-
----
-
-#### `op.getDeviceId()`
-
-⚠️ **Deprecated** — Use `getVisitorId()` instead.
-
-Returns the device ID.
-
-**Returns:** `Promise<string>`
-
-```js
-const deviceId = await op.getDeviceId();
-```
-
----
-
-### Timing
-
-#### `op.timeEvent(eventName)`
-
-Begin timing an event. When you later call `track()` with the same event name, the event will include a `$duration` property (in seconds).
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `eventName` | `string` | Yes | Name of the event to time |
-
-**Returns:** `void`
-
-```js
-op.timeEvent('Video Watched');
-
-// ... later:
-op.track('Video Watched', { video_id: 'abc123' }); // includes $duration
-```
-
----
-
-#### `op.eventElapsedTime(eventName)`
-
-Get the elapsed time in seconds since `timeEvent()` was called for the given event, without sending the event.
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `eventName` | `string` | Yes | Name of the previously timed event |
-
-**Returns:** `Promise<number>` — elapsed seconds
-
-```js
-op.timeEvent('Checkout');
-// ... later:
-const elapsed = await op.eventElapsedTime('Checkout');
-console.log(`Checkout has been open for ${elapsed}s`);
-```
-
----
-
 ### Privacy Controls
 
 #### `op.optOutTracking()`
@@ -566,115 +496,6 @@ const hasOptedOut = await op.hasOptedOutTracking();
 if (hasOptedOut) {
   console.log('User has opted out');
 }
-```
-
----
-
-### Deprecated Methods
-
-The following methods are kept for backwards compatibility but should not be used in new code.
-
-#### ⚠️ `op.registerSuperProperties(properties)`
-
-**Deprecated** — Use `updateDefaultEventProperties()` instead.
-
-Register properties that will be sent with every future `track()` call.
-
-```js
-// Deprecated
-op.registerSuperProperties({ plan: 'pro' });
-
-// Use instead
-op.updateDefaultEventProperties({ plan: 'pro' });
-```
-
----
-
-#### ⚠️ `op.registerSuperPropertiesOnce(properties)`
-
-**Deprecated** — Use `updateDefaultEventProperties()` instead.
-
-Register super properties only if those keys have not already been registered.
-
-```js
-// Deprecated
-op.registerSuperPropertiesOnce({ first_open: true });
-```
-
----
-
-#### ⚠️ `op.getSuperProperties()`
-
-**Deprecated** — Use `updateDefaultEventProperties()` instead.
-
-Returns the currently registered super properties.
-
-**Returns:** `Promise<object>`
-
-```js
-// Deprecated
-const props = await op.getSuperProperties();
-```
-
----
-
-#### ⚠️ `op.unregisterSuperProperty(propertyName)`
-
-**Deprecated** — Use `updateDefaultEventProperties()` instead.
-
-Remove a single super property so it is no longer sent with future events.
-
-```js
-// Deprecated
-op.unregisterSuperProperty('experiment_group');
-```
-
----
-
-#### ⚠️ `op.clearSuperProperties()`
-
-**Deprecated** — Use `updateDefaultEventProperties()` instead.
-
-Remove all registered super properties.
-
-```js
-// Deprecated
-op.clearSuperProperties();
-```
-
----
-
-#### ⚠️ `op.alias(alias, distinctId)`
-
-**Deprecated.** Creates an alias mapping one ID to another.
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `alias` | `string` | The new alias identifier |
-| `distinctId` | `string` | The existing distinct ID to map to |
-
-**Returns:** `void`
-
-```js
-// Deprecated
-op.alias('user-123', op.getVisitorId());
-```
-
----
-
-#### ⚠️ `OursPrivacy.init(token, trackAutomaticEvents, optOutTrackingDefault?)` (static)
-
-**Deprecated** — Use `new OursPrivacy(...).init()` instead.
-
-The static `init` method was the original initialization pattern. It bypasses the JavaScript fallback path and only works with native modules.
-
-```js
-// Deprecated (static form)
-const op = await OursPrivacy.init('YOUR_API_TOKEN', false);
-
-// Use instead (instance form)
-const op = new OursPrivacy('YOUR_API_TOKEN', false);
-await op.init();
 ```
 
 ---
@@ -769,33 +590,26 @@ const op = new OursPrivacy('TOKEN', false);
 await op.init();
 ```
 
-### Super properties → Default properties
+### Default properties
 
-The `registerSuperProperties` family of methods is deprecated in favor of the new default properties API, which maps directly to the Ours Privacy event schema:
+Replace `registerSuperProperties` with the Ours Privacy default properties API:
 
 ```js
-// Before (Mixpanel-style super properties)
-op.registerSuperProperties({ plan: 'pro', environment: 'production' });
-
-// After (Ours Privacy default event properties)
+// Event properties sent with every track() call
 op.updateDefaultEventProperties({ plan: 'pro', environment: 'production' });
 
-// New: per-user custom properties sent on every event
+// Per-user custom properties sent on every event
 op.updateDefaultUserCustomProperties({ tier: 'enterprise' });
 
-// New: consent state sent on every event
+// Consent state sent on every event
 op.updateDefaultUserConsentProperties({ marketing: true, analytics: true });
 ```
 
-### Distinct ID
+### Visitor ID
 
-Mixpanel's distinct ID could include a device-prefix (e.g. `$device:uuid`). Ours Privacy uses a clean UUID with no prefix:
+Use `getVisitorId()` instead of `getDistinctId()` — it returns a clean UUID synchronously:
 
 ```js
-// Before (may return "$device:uuid" string)
-const id = await op.getDistinctId();
-
-// After (returns clean UUID)
 const id = op.getVisitorId();
 ```
 
@@ -828,10 +642,6 @@ await op.init(false, { serverURL: 'https://api-eu.oursprivacy.com' });
 // or
 op.setServerURL('https://api-eu.oursprivacy.com');
 ```
-
-**What is the difference between `getVisitorId()` and `getDistinctId()`?**
-
-`getVisitorId()` returns a clean UUID with no prefix and is synchronous. `getDistinctId()` is asynchronous and may return a prefixed string on older SDK versions. Use `getVisitorId()` for all new code.
 
 ---
 

--- a/__tests__/core.test.js
+++ b/__tests__/core.test.js
@@ -30,7 +30,6 @@ jest.mock("oursprivacy-react-native/javascript/oursprivacy-config", () => ({
       getFlushInterval: jest.fn().mockReturnValue(1000),
       getFlushBatchSize: jest.fn().mockReturnValue(50),
       getServerURL: jest.fn(),
-      getUseIpAddressForGeolocation: jest.fn(),
       getIsManuallySetId: jest.fn().mockReturnValue(false),
     }),
   },

--- a/__tests__/core.test.js
+++ b/__tests__/core.test.js
@@ -31,6 +31,7 @@ jest.mock("oursprivacy-react-native/javascript/oursprivacy-config", () => ({
       getFlushBatchSize: jest.fn().mockReturnValue(50),
       getServerURL: jest.fn(),
       getUseIpAddressForGeolocation: jest.fn(),
+      getIsManuallySetId: jest.fn().mockReturnValue(false),
     }),
   },
 }));
@@ -131,5 +132,38 @@ describe("OursPrivacyQueueManager", () => {
     });
     await OursPrivacyCore().flush(token);
     expect(OursPrivacyNetwork.sendRequest).toHaveBeenCalledTimes(0);
+  });
+
+  it("passes isManuallySetId from config to sendRequest", async () => {
+    const { OursPrivacyConfig } = require("oursprivacy-react-native/javascript/oursprivacy-config");
+    OursPrivacyConfig.getInstance().getIsManuallySetId.mockReturnValueOnce(true);
+    OursPrivacyPersistent.getInstance().getOptedOut.mockReturnValueOnce(false);
+    OursPrivacyQueueManager.getQueue.mockImplementation(() => [data]);
+
+    await OursPrivacyCore().flush(token);
+
+    expect(OursPrivacyNetwork.sendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ isManuallySetId: true })
+    );
+  });
+
+  it("enqueues event data without adding session metadata", async () => {
+    OursPrivacyPersistent.getInstance().getOptedOut.mockReturnValueOnce(false);
+    const eventData = {
+      event: "Purchase",
+      visitor_id: "uuid-123",
+      distinct_id: "per-event-uuid",
+      eventProperties: { price: 99 },
+      userProperties: null,
+      defaultProperties: { device_type: "mobile" },
+    };
+
+    await OursPrivacyCore().addToOursPrivacyQueue(token, type, eventData);
+
+    expect(OursPrivacyQueueManager.enqueue).toHaveBeenCalledWith(
+      token,
+      type,
+      eventData
+    );
   });
 });

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -13,15 +13,21 @@ test(`it calls OursPrivacyReactNative initialize`, async () => {
   );
 });
 
-test(`it calls OursPrivacyReactNative initialize with optOut and options`, async () => {
+test(`it calls OursPrivacyReactNative initialize with optOut, passing empty props map to bridge`, async () => {
   const oursprivacy = new OursPrivacy("token", true);
   await oursprivacy.init(true, {default_event_properties: {prop: "value"}});
+  // Native bridge gets {} as properties (not the raw options object)
   expect(NativeModules.OursPrivacyReactNative.initialize).toBeCalledWith(
     "token",
     true,
     true,
-    {default_event_properties: {prop: "value"}},
+    {},
     "https://cdn.oursprivacy.com"
+  );
+  // default_event_properties are forwarded via registerSuperProperties
+  expect(NativeModules.OursPrivacyReactNative.registerSuperProperties).toBeCalledWith(
+    "token",
+    {prop: "value"}
   );
 });
 
@@ -116,29 +122,23 @@ test(`it calls OursPrivacyReactNative reset`, async () => {
   expect(NativeModules.OursPrivacyReactNative.reset).toBeCalledWith("token");
 });
 
-test(`it calls OursPrivacyReactNative updateDefaultEventProperties`, async () => {
+test(`updateDefaultEventProperties delegates to registerSuperProperties on native`, async () => {
   const oursprivacy = new OursPrivacy("token", true);
   oursprivacy.updateDefaultEventProperties({tier: "pro"});
-  expect(NativeModules.OursPrivacyReactNative.updateDefaultEventProperties).toBeCalledWith(
+  expect(NativeModules.OursPrivacyReactNative.registerSuperProperties).toBeCalledWith(
     "token",
     {tier: "pro"}
   );
 });
 
-test(`it calls OursPrivacyReactNative updateDefaultUserCustomProperties`, async () => {
+test(`updateDefaultUserCustomProperties stores JS-side on native (no bridge equivalent)`, async () => {
   const oursprivacy = new OursPrivacy("token", true);
   oursprivacy.updateDefaultUserCustomProperties({plan: "enterprise"});
-  expect(NativeModules.OursPrivacyReactNative.updateDefaultUserCustomProperties).toBeCalledWith(
-    "token",
-    {plan: "enterprise"}
-  );
+  expect(oursprivacy._defaultUserCustomProperties).toEqual({plan: "enterprise"});
 });
 
-test(`it calls OursPrivacyReactNative updateDefaultUserConsentProperties`, async () => {
+test(`updateDefaultUserConsentProperties stores JS-side on native (no bridge equivalent)`, async () => {
   const oursprivacy = new OursPrivacy("token", true);
   oursprivacy.updateDefaultUserConsentProperties({marketing: true});
-  expect(NativeModules.OursPrivacyReactNative.updateDefaultUserConsentProperties).toBeCalledWith(
-    "token",
-    {marketing: true}
-  );
+  expect(oursprivacy._defaultUserConsentProperties).toEqual({marketing: true});
 });

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,144 +1,170 @@
 import {OursPrivacy} from "oursprivacy-react-native";
-import {NativeModules} from "react-native";
 
-test(`it calls OursPrivacyReactNative initialize`, async () => {
-  const oursprivacy = new OursPrivacy("token", true);
-  await oursprivacy.init();
-  expect(NativeModules.OursPrivacyReactNative.initialize).toBeCalledWith(
+// OursPrivacy always uses JS mode. Mock OursPrivacyMain so index.test.js
+// verifies the wrapper delegates correctly without executing JS SDK internals.
+jest.mock("oursprivacy-react-native/javascript/oursprivacy-main", () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+      initialize: jest.fn().mockResolvedValue(undefined),
+      setServerURL: jest.fn(),
+      setLoggingEnabled: jest.fn(),
+      setFlushOnBackground: jest.fn(),
+      setFlushBatchSize: jest.fn(),
+      hasOptedOutTracking: jest.fn().mockResolvedValue(false),
+      optInTracking: jest.fn(),
+      optOutTracking: jest.fn(),
+      identify: jest.fn().mockResolvedValue(undefined),
+      track: jest.fn(),
+      reset: jest.fn(),
+      flush: jest.fn(),
+      getVisitorId: jest.fn().mockReturnValue("mock-visitor-id"),
+      updateDefaultEventProperties: jest.fn(),
+      updateDefaultUserCustomProperties: jest.fn(),
+      updateDefaultUserConsentProperties: jest.fn(),
+    })),
+}));
+
+test(`it initializes with correct defaults`, async () => {
+  const op = new OursPrivacy("token", false);
+  await op.init();
+  expect(op.oursprivacyImpl.initialize).toBeCalledWith(
     "token",
-    true,
+    false,
     false,
     {},
     "https://cdn.oursprivacy.com"
   );
 });
 
-test(`it calls OursPrivacyReactNative initialize with optOut, passing empty props map to bridge`, async () => {
-  const oursprivacy = new OursPrivacy("token", true);
-  await oursprivacy.init(true, {default_event_properties: {prop: "value"}});
-  // Native bridge gets {} as properties (not the raw options object)
-  expect(NativeModules.OursPrivacyReactNative.initialize).toBeCalledWith(
+test(`it passes optOut and options to initialize`, async () => {
+  const op = new OursPrivacy("token", false);
+  await op.init(true, {default_event_properties: {prop: "value"}});
+  expect(op.oursprivacyImpl.initialize).toBeCalledWith(
     "token",
+    false,
     true,
-    true,
-    {},
+    {default_event_properties: {prop: "value"}},
     "https://cdn.oursprivacy.com"
-  );
-  // default_event_properties are forwarded via registerSuperProperties
-  expect(NativeModules.OursPrivacyReactNative.registerSuperProperties).toBeCalledWith(
-    "token",
-    {prop: "value"}
   );
 });
 
-test(`it calls OursPrivacyReactNative setServerURL`, async () => {
-  const oursprivacy = new OursPrivacy("token", true);
-  oursprivacy.setServerURL("https://api-eu.oursprivacy.com");
-  expect(NativeModules.OursPrivacyReactNative.setServerURL).toBeCalledWith(
+test(`it passes visitor_id option through to initialize`, async () => {
+  const op = new OursPrivacy("token", false);
+  await op.init(false, {visitor_id: "preset-visitor-123"});
+  expect(op.oursprivacyImpl.initialize).toBeCalledWith(
+    "token",
+    false,
+    false,
+    {visitor_id: "preset-visitor-123"},
+    "https://cdn.oursprivacy.com"
+  );
+});
+
+test(`it calls setServerURL`, async () => {
+  const op = new OursPrivacy("token", false);
+  op.setServerURL("https://api-eu.oursprivacy.com");
+  expect(op.oursprivacyImpl.setServerURL).toBeCalledWith(
     "token",
     "https://api-eu.oursprivacy.com"
   );
 });
 
-test(`it calls OursPrivacyReactNative setLoggingEnabled`, async () => {
-  const oursprivacy = new OursPrivacy("token", true);
-  oursprivacy.setLoggingEnabled(true);
-  expect(NativeModules.OursPrivacyReactNative.setLoggingEnabled).toBeCalledWith(
-    "token",
-    true
-  );
+test(`it calls setLoggingEnabled`, async () => {
+  const op = new OursPrivacy("token", false);
+  op.setLoggingEnabled(true);
+  expect(op.oursprivacyImpl.setLoggingEnabled).toBeCalledWith("token", true);
 });
 
-test(`it calls OursPrivacyReactNative setFlushBatchSize`, async () => {
-  const oursprivacy = new OursPrivacy("token", true);
-  oursprivacy.setFlushBatchSize(20);
-  expect(NativeModules.OursPrivacyReactNative.setFlushBatchSize).toBeCalledWith(
-    "token",
-    20
-  );
+test(`it calls setFlushBatchSize`, async () => {
+  const op = new OursPrivacy("token", false);
+  op.setFlushBatchSize(20);
+  expect(op.oursprivacyImpl.setFlushBatchSize).toBeCalledWith("token", 20);
 });
 
-test(`it calls OursPrivacyReactNative hasOptedOutTracking`, async () => {
-  const oursprivacy = new OursPrivacy("token", true);
-  oursprivacy.hasOptedOutTracking();
-  expect(NativeModules.OursPrivacyReactNative.hasOptedOutTracking).toBeCalledWith(
-    "token"
-  );
+test(`it calls hasOptedOutTracking`, async () => {
+  const op = new OursPrivacy("token", false);
+  op.hasOptedOutTracking();
+  expect(op.oursprivacyImpl.hasOptedOutTracking).toBeCalledWith("token");
 });
 
-test(`it calls OursPrivacyReactNative optInTracking`, async () => {
-  const oursprivacy = new OursPrivacy("token", true);
-  oursprivacy.optInTracking();
-  expect(NativeModules.OursPrivacyReactNative.optInTracking).toBeCalledWith(
-    "token"
-  );
+test(`it calls optInTracking`, async () => {
+  const op = new OursPrivacy("token", false);
+  op.optInTracking();
+  expect(op.oursprivacyImpl.optInTracking).toBeCalledWith("token");
 });
 
-test(`it calls OursPrivacyReactNative optOutTracking`, async () => {
-  const oursprivacy = new OursPrivacy("token", true);
-  oursprivacy.optOutTracking();
-  expect(NativeModules.OursPrivacyReactNative.optOutTracking).toBeCalledWith(
-    "token"
-  );
+test(`it calls optOutTracking`, async () => {
+  const op = new OursPrivacy("token", false);
+  op.optOutTracking();
+  expect(op.oursprivacyImpl.optOutTracking).toBeCalledWith("token");
 });
 
-test(`it calls OursPrivacyReactNative identify`, async () => {
-  const oursprivacy = new OursPrivacy("token", true);
-  oursprivacy.identify("user@example.com");
-  expect(NativeModules.OursPrivacyReactNative.identify).toBeCalledWith(
+test(`it calls identify with id`, async () => {
+  const op = new OursPrivacy("token", false);
+  await op.identify("user@example.com");
+  expect(op.oursprivacyImpl.identify).toBeCalledWith(
     "token",
     "user@example.com",
     undefined
   );
 });
 
-test(`it calls OursPrivacyReactNative identify with userProperties`, async () => {
-  const oursprivacy = new OursPrivacy("token", true);
-  oursprivacy.identify("user@example.com", {email: "user@example.com", external_id: "123"});
-  expect(NativeModules.OursPrivacyReactNative.identify).toBeCalledWith(
+test(`it calls identify with id and userProperties`, async () => {
+  const op = new OursPrivacy("token", false);
+  await op.identify("user@example.com", {email: "user@example.com", external_id: "123"});
+  expect(op.oursprivacyImpl.identify).toBeCalledWith(
     "token",
     "user@example.com",
     {email: "user@example.com", external_id: "123"}
   );
 });
 
-test(`it calls OursPrivacyReactNative track`, async () => {
-  const oursprivacy = new OursPrivacy("token", true);
-  oursprivacy.track("event name", {
-    "Cool Property": "Property Value",
-  });
-  expect(NativeModules.OursPrivacyReactNative.track).toBeCalledWith(
+test(`it calls track`, async () => {
+  const op = new OursPrivacy("token", false);
+  op.track("event name", {"Cool Property": "Property Value"});
+  expect(op.oursprivacyImpl.track).toBeCalledWith(
     "token",
     "event name",
-    {
-      "Cool Property": "Property Value",
-    }
+    {"Cool Property": "Property Value"}
   );
 });
 
-test(`it calls OursPrivacyReactNative reset`, async () => {
-  const oursprivacy = new OursPrivacy("token", true);
-  oursprivacy.reset();
-  expect(NativeModules.OursPrivacyReactNative.reset).toBeCalledWith("token");
+test(`it calls reset`, async () => {
+  const op = new OursPrivacy("token", false);
+  op.reset();
+  expect(op.oursprivacyImpl.reset).toBeCalledWith("token");
 });
 
-test(`updateDefaultEventProperties delegates to registerSuperProperties on native`, async () => {
-  const oursprivacy = new OursPrivacy("token", true);
-  oursprivacy.updateDefaultEventProperties({tier: "pro"});
-  expect(NativeModules.OursPrivacyReactNative.registerSuperProperties).toBeCalledWith(
+test(`it calls getVisitorId`, async () => {
+  const op = new OursPrivacy("token", false);
+  const id = op.getVisitorId();
+  expect(op.oursprivacyImpl.getVisitorId).toBeCalledWith("token");
+  expect(id).toBe("mock-visitor-id");
+});
+
+test(`it calls updateDefaultEventProperties`, async () => {
+  const op = new OursPrivacy("token", false);
+  op.updateDefaultEventProperties({tier: "pro"});
+  expect(op.oursprivacyImpl.updateDefaultEventProperties).toBeCalledWith(
     "token",
     {tier: "pro"}
   );
 });
 
-test(`updateDefaultUserCustomProperties stores JS-side on native (no bridge equivalent)`, async () => {
-  const oursprivacy = new OursPrivacy("token", true);
-  oursprivacy.updateDefaultUserCustomProperties({plan: "enterprise"});
-  expect(oursprivacy._defaultUserCustomProperties).toEqual({plan: "enterprise"});
+test(`it calls updateDefaultUserCustomProperties`, async () => {
+  const op = new OursPrivacy("token", false);
+  op.updateDefaultUserCustomProperties({plan: "enterprise"});
+  expect(op.oursprivacyImpl.updateDefaultUserCustomProperties).toBeCalledWith(
+    "token",
+    {plan: "enterprise"}
+  );
 });
 
-test(`updateDefaultUserConsentProperties stores JS-side on native (no bridge equivalent)`, async () => {
-  const oursprivacy = new OursPrivacy("token", true);
-  oursprivacy.updateDefaultUserConsentProperties({marketing: true});
-  expect(oursprivacy._defaultUserConsentProperties).toEqual({marketing: true});
+test(`it calls updateDefaultUserConsentProperties`, async () => {
+  const op = new OursPrivacy("token", false);
+  op.updateDefaultUserConsentProperties({marketing: true});
+  expect(op.oursprivacyImpl.updateDefaultUserConsentProperties).toBeCalledWith(
+    "token",
+    {marketing: true}
+  );
 });

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -2,35 +2,31 @@ import {OursPrivacy} from "oursprivacy-react-native";
 import {NativeModules} from "react-native";
 
 test(`it calls OursPrivacyReactNative initialize`, async () => {
-  const oursprivacy = await OursPrivacy.init("token", true);
+  const oursprivacy = new OursPrivacy("token", true);
+  await oursprivacy.init();
   expect(NativeModules.OursPrivacyReactNative.initialize).toBeCalledWith(
     "token",
     true,
     false,
-    {$lib_version: expect.any(String), op_lib: "react-native"},
-    "https://api.oursprivacy.com/api/v1"
+    {},
+    "https://cdn.oursprivacy.com"
   );
 });
 
-test(`it calls OursPrivacyReactNative initialize with optOut and superProperties`, async () => {
+test(`it calls OursPrivacyReactNative initialize with optOut and options`, async () => {
   const oursprivacy = new OursPrivacy("token", true);
-  oursprivacy.init(true, {super: "property"});
+  await oursprivacy.init(true, {default_event_properties: {prop: "value"}});
   expect(NativeModules.OursPrivacyReactNative.initialize).toBeCalledWith(
     "token",
     true,
     true,
-    {
-      $lib_version: expect.any(String),
-      op_lib: "react-native",
-      super: "property",
-    },
-    "https://api.oursprivacy.com/api/v1"
+    {default_event_properties: {prop: "value"}},
+    "https://cdn.oursprivacy.com"
   );
 });
 
 test(`it calls OursPrivacyReactNative setServerURL`, async () => {
   const oursprivacy = new OursPrivacy("token", true);
-  oursprivacy.init();
   oursprivacy.setServerURL("https://api-eu.oursprivacy.com");
   expect(NativeModules.OursPrivacyReactNative.setServerURL).toBeCalledWith(
     "token",
@@ -40,7 +36,6 @@ test(`it calls OursPrivacyReactNative setServerURL`, async () => {
 
 test(`it calls OursPrivacyReactNative setLoggingEnabled`, async () => {
   const oursprivacy = new OursPrivacy("token", true);
-  oursprivacy.init();
   oursprivacy.setLoggingEnabled(true);
   expect(NativeModules.OursPrivacyReactNative.setLoggingEnabled).toBeCalledWith(
     "token",
@@ -50,7 +45,6 @@ test(`it calls OursPrivacyReactNative setLoggingEnabled`, async () => {
 
 test(`it calls OursPrivacyReactNative setUseIpAddressForGeolocation`, async () => {
   const oursprivacy = new OursPrivacy("token", true);
-  oursprivacy.init();
   oursprivacy.setUseIpAddressForGeolocation(true);
   expect(
     NativeModules.OursPrivacyReactNative.setUseIpAddressForGeolocation
@@ -59,7 +53,6 @@ test(`it calls OursPrivacyReactNative setUseIpAddressForGeolocation`, async () =
 
 test(`it calls OursPrivacyReactNative setFlushBatchSize`, async () => {
   const oursprivacy = new OursPrivacy("token", true);
-  oursprivacy.init();
   oursprivacy.setFlushBatchSize(20);
   expect(NativeModules.OursPrivacyReactNative.setFlushBatchSize).toBeCalledWith(
     "token",
@@ -69,7 +62,6 @@ test(`it calls OursPrivacyReactNative setFlushBatchSize`, async () => {
 
 test(`it calls OursPrivacyReactNative hasOptedOutTracking`, async () => {
   const oursprivacy = new OursPrivacy("token", true);
-  oursprivacy.init();
   oursprivacy.hasOptedOutTracking();
   expect(NativeModules.OursPrivacyReactNative.hasOptedOutTracking).toBeCalledWith(
     "token"
@@ -78,7 +70,6 @@ test(`it calls OursPrivacyReactNative hasOptedOutTracking`, async () => {
 
 test(`it calls OursPrivacyReactNative optInTracking`, async () => {
   const oursprivacy = new OursPrivacy("token", true);
-  oursprivacy.init();
   oursprivacy.optInTracking();
   expect(NativeModules.OursPrivacyReactNative.optInTracking).toBeCalledWith(
     "token"
@@ -87,7 +78,6 @@ test(`it calls OursPrivacyReactNative optInTracking`, async () => {
 
 test(`it calls OursPrivacyReactNative optOutTracking`, async () => {
   const oursprivacy = new OursPrivacy("token", true);
-  oursprivacy.init();
   oursprivacy.optOutTracking();
   expect(NativeModules.OursPrivacyReactNative.optOutTracking).toBeCalledWith(
     "token"
@@ -96,28 +86,26 @@ test(`it calls OursPrivacyReactNative optOutTracking`, async () => {
 
 test(`it calls OursPrivacyReactNative identify`, async () => {
   const oursprivacy = new OursPrivacy("token", true);
-  oursprivacy.init();
-  oursprivacy.identify("distinct_id");
+  oursprivacy.identify("user@example.com");
   expect(NativeModules.OursPrivacyReactNative.identify).toBeCalledWith(
     "token",
-    "distinct_id",
+    "user@example.com",
     undefined
   );
 });
 
-test(`it calls OursPrivacyReactNative alias`, async () => {
+test(`it calls OursPrivacyReactNative identify with userProperties`, async () => {
   const oursprivacy = new OursPrivacy("token", true);
-  oursprivacy.init();
-  oursprivacy.alias("alias", "distinct_id");
-  expect(NativeModules.OursPrivacyReactNative.alias).toBeCalledWith(
+  oursprivacy.identify("user@example.com", {email: "user@example.com", external_id: "123"});
+  expect(NativeModules.OursPrivacyReactNative.identify).toBeCalledWith(
     "token",
-    "alias",
-    "distinct_id"
+    "user@example.com",
+    {email: "user@example.com", external_id: "123"}
   );
 });
 
 test(`it calls OursPrivacyReactNative track`, async () => {
-  const oursprivacy = await OursPrivacy.init("token", true);
+  const oursprivacy = new OursPrivacy("token", true);
   oursprivacy.track("event name", {
     "Cool Property": "Property Value",
   });
@@ -126,102 +114,39 @@ test(`it calls OursPrivacyReactNative track`, async () => {
     "event name",
     {
       "Cool Property": "Property Value",
-      $lib_version: expect.any(String),
-      op_lib: "react-native",
     }
-  );
-});
-
-test(`it calls OursPrivacyReactNative registerSuperProperties`, async () => {
-  const oursprivacy = new OursPrivacy("token", true);
-  oursprivacy.init();
-  oursprivacy.registerSuperProperties({
-    "super property": "super property value",
-    "super property1": "super property value1",
-  });
-  expect(
-    NativeModules.OursPrivacyReactNative.registerSuperProperties
-  ).toBeCalledWith("token", {
-    "super property": "super property value",
-    "super property1": "super property value1",
-  });
-});
-
-test(`it calls OursPrivacyReactNative registerSuperPropertiesOnce`, async () => {
-  const oursprivacy = new OursPrivacy("token", true);
-  oursprivacy.init();
-  oursprivacy.registerSuperPropertiesOnce({
-    "super property": "super property value",
-    "super property1": "super property value1",
-  });
-  expect(
-    NativeModules.OursPrivacyReactNative.registerSuperProperties
-  ).toBeCalledWith("token", {
-    "super property": "super property value",
-    "super property1": "super property value1",
-  });
-});
-
-test(`it calls OursPrivacyReactNative unregisterSuperProperty`, async () => {
-  const oursprivacy = new OursPrivacy("token", true);
-  oursprivacy.init();
-  oursprivacy.unregisterSuperProperty("super property");
-  expect(
-    NativeModules.OursPrivacyReactNative.unregisterSuperProperty
-  ).toBeCalledWith("token", "super property");
-});
-
-test(`it calls OursPrivacyReactNative getSuperProperties`, async () => {
-  const oursprivacy = new OursPrivacy("token", true);
-  oursprivacy.init();
-  oursprivacy.getSuperProperties();
-  expect(NativeModules.OursPrivacyReactNative.getSuperProperties).toBeCalledWith(
-    "token"
-  );
-});
-
-test(`it calls OursPrivacyReactNative clearSuperProperties`, async () => {
-  const oursprivacy = new OursPrivacy("token", true);
-  oursprivacy.init();
-  oursprivacy.clearSuperProperties();
-  expect(NativeModules.OursPrivacyReactNative.clearSuperProperties).toBeCalledWith(
-    "token"
-  );
-});
-
-test(`it calls OursPrivacyReactNative timeEvent`, async () => {
-  const oursprivacy = new OursPrivacy("token", true);
-  oursprivacy.init();
-  oursprivacy.timeEvent("Timed Event");
-  expect(NativeModules.OursPrivacyReactNative.timeEvent).toBeCalledWith(
-    "token",
-    "Timed Event"
-  );
-});
-
-test(`it calls OursPrivacyReactNative eventElapsedTime`, async () => {
-  const oursprivacy = new OursPrivacy("token", true);
-  oursprivacy.init();
-  oursprivacy.eventElapsedTime("Timed Event");
-  expect(NativeModules.OursPrivacyReactNative.eventElapsedTime).toBeCalledWith(
-    "token",
-    "Timed Event"
   );
 });
 
 test(`it calls OursPrivacyReactNative reset`, async () => {
   const oursprivacy = new OursPrivacy("token", true);
-  oursprivacy.init();
   oursprivacy.reset();
   expect(NativeModules.OursPrivacyReactNative.reset).toBeCalledWith("token");
 });
 
-test(`it calls OursPrivacyReactNative getDistinctId`, async () => {
+test(`it calls OursPrivacyReactNative updateDefaultEventProperties`, async () => {
   const oursprivacy = new OursPrivacy("token", true);
-  oursprivacy.init();
-  oursprivacy.getDistinctId();
-  expect(NativeModules.OursPrivacyReactNative.getDistinctId).toBeCalledWith(
-    "token"
+  oursprivacy.updateDefaultEventProperties({tier: "pro"});
+  expect(NativeModules.OursPrivacyReactNative.updateDefaultEventProperties).toBeCalledWith(
+    "token",
+    {tier: "pro"}
   );
 });
 
+test(`it calls OursPrivacyReactNative updateDefaultUserCustomProperties`, async () => {
+  const oursprivacy = new OursPrivacy("token", true);
+  oursprivacy.updateDefaultUserCustomProperties({plan: "enterprise"});
+  expect(NativeModules.OursPrivacyReactNative.updateDefaultUserCustomProperties).toBeCalledWith(
+    "token",
+    {plan: "enterprise"}
+  );
+});
+
+test(`it calls OursPrivacyReactNative updateDefaultUserConsentProperties`, async () => {
+  const oursprivacy = new OursPrivacy("token", true);
+  oursprivacy.updateDefaultUserConsentProperties({marketing: true});
+  expect(NativeModules.OursPrivacyReactNative.updateDefaultUserConsentProperties).toBeCalledWith(
+    "token",
+    {marketing: true}
+  );
+});

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -43,14 +43,6 @@ test(`it calls OursPrivacyReactNative setLoggingEnabled`, async () => {
   );
 });
 
-test(`it calls OursPrivacyReactNative setUseIpAddressForGeolocation`, async () => {
-  const oursprivacy = new OursPrivacy("token", true);
-  oursprivacy.setUseIpAddressForGeolocation(true);
-  expect(
-    NativeModules.OursPrivacyReactNative.setUseIpAddressForGeolocation
-  ).toBeCalledWith("token", true);
-});
-
 test(`it calls OursPrivacyReactNative setFlushBatchSize`, async () => {
   const oursprivacy = new OursPrivacy("token", true);
   oursprivacy.setFlushBatchSize(20);

--- a/__tests__/integration.test.js
+++ b/__tests__/integration.test.js
@@ -1,0 +1,119 @@
+import fetchMock from "jest-fetch-mock";
+
+fetchMock.enableMocks();
+
+const flushAsyncWork = async (turns = 5) => {
+  for (let index = 0; index < turns; index += 1) {
+    await Promise.resolve();
+  }
+};
+
+const waitForFetchCalls = async (count, attempts = 20) => {
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    if (fetchMock.mock.calls.length >= count) {
+      return;
+    }
+    await flushAsyncWork(1);
+  }
+  expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(count);
+};
+
+describe("OursPrivacy integration flows", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    fetchMock.resetMocks();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it("runs init -> track -> flush through the real JS stack", async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({success: true}), {status: 200});
+
+    const {OursPrivacy} = require("oursprivacy-react-native");
+    const op = new OursPrivacy("test-token", false);
+
+    await op.init(false, {
+      serverURL: "https://api.oursprivacy.com",
+      visitor_id: "preset-visitor-123",
+      default_event_properties: {platform: "mobile"},
+      default_user_custom_properties: {plan: "pro"},
+      default_user_consent_properties: {marketing: true},
+    });
+
+    op.track("Purchase", {price: 99});
+    await flushAsyncWork();
+    op.flush();
+    await waitForFetchCalls(1);
+
+    const [url, options] = fetchMock.mock.calls[0];
+    const body = JSON.parse(options.body);
+
+    expect(url).toBe("https://api.oursprivacy.com/ingest");
+    expect(body.token).toBe("test-token");
+    expect(body.is_manually_set_id).toBe(true);
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0]).toEqual(
+      expect.objectContaining({
+        event: "Purchase",
+        visitor_id: "preset-visitor-123",
+        distinct_id: "mock-uuid-v4",
+        eventProperties: {
+          platform: "mobile",
+          price: 99,
+        },
+        userProperties: {
+          custom_properties: {plan: "pro"},
+          consent: {marketing: true},
+        },
+        defaultProperties: expect.objectContaining({
+          device_type: "mobile",
+          os_name: "iOS",
+          version: expect.any(String),
+        }),
+      })
+    );
+  });
+
+  it("drops pre-opt-out queued events across optOut -> optIn -> track -> flush", async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({success: true}), {status: 200});
+
+    const {OursPrivacy} = require("oursprivacy-react-native");
+    const op = new OursPrivacy("test-token", false);
+
+    await op.init(false, {
+      serverURL: "https://api-eu.oursprivacy.com",
+      visitor_id: "preset-visitor-123",
+    });
+
+    op.track("Before Opt Out", {step: 1});
+    await flushAsyncWork();
+
+    op.optOutTracking();
+    await flushAsyncWork();
+    expect(op.hasOptedOutTracking()).toBe(true);
+
+    op.optInTracking();
+    await flushAsyncWork();
+    expect(op.hasOptedOutTracking()).toBe(false);
+
+    op.track("After Opt In", {step: 2});
+    await flushAsyncWork();
+
+    op.flush();
+    await waitForFetchCalls(1);
+
+    const [url, options] = fetchMock.mock.calls[0];
+    const body = JSON.parse(options.body);
+    const eventNames = body.data.map((event) => event.event);
+
+    expect(url).toBe("https://api-eu.oursprivacy.com/ingest");
+    expect(eventNames).toEqual(["$opt_in", "After Opt In"]);
+    expect(eventNames).not.toContain("Before Opt Out");
+  });
+});

--- a/__tests__/jest_setup.js
+++ b/__tests__/jest_setup.js
@@ -19,24 +19,7 @@ jest.mock("@react-native-async-storage/async-storage", () => ({
 
 jest.mock("react-native", () => ({
   Platform: { OS: "ios", select: jest.fn((obj) => obj.ios) },
-  NativeModules: {
-    OursPrivacyReactNative: {
-      initialize: jest.fn(),
-      setServerURL: jest.fn(),
-      setLoggingEnabled: jest.fn(),
-      setFlushOnBackground: jest.fn(),
-      setFlushBatchSize: jest.fn(),
-      hasOptedOutTracking: jest.fn(),
-      optInTracking: jest.fn(),
-      optOutTracking: jest.fn(),
-      identify: jest.fn().mockResolvedValue(undefined),
-      track: jest.fn(),
-      reset: jest.fn(),
-      getDeviceId: jest.fn().mockResolvedValue("mock-visitor-id"),
-      registerSuperProperties: jest.fn().mockResolvedValue(undefined),
-      flush: jest.fn(),
-    },
-  },
+  NativeModules: {},
   AppState: {
     addEventListener: jest.fn(),
     removeEventListener: jest.fn(),

--- a/__tests__/jest_setup.js
+++ b/__tests__/jest_setup.js
@@ -32,10 +32,9 @@ jest.mock("react-native", () => ({
       identify: jest.fn().mockResolvedValue(undefined),
       track: jest.fn(),
       reset: jest.fn(),
-      getVisitorId: jest.fn().mockReturnValue("mock-visitor-id"),
-      updateDefaultEventProperties: jest.fn(),
-      updateDefaultUserCustomProperties: jest.fn(),
-      updateDefaultUserConsentProperties: jest.fn(),
+      getDeviceId: jest.fn().mockResolvedValue("mock-visitor-id"),
+      registerSuperProperties: jest.fn().mockResolvedValue(undefined),
+      flush: jest.fn(),
     },
   },
   AppState: {

--- a/__tests__/jest_setup.js
+++ b/__tests__/jest_setup.js
@@ -8,7 +8,7 @@ jest.mock("../javascript/oursprivacy-storage", () => {
   };
 });
 jest.mock("uuid", () => ({
-  v4: jest.fn(),
+  v4: jest.fn().mockReturnValue("mock-uuid-v4"),
 }));
 
 jest.mock("@react-native-async-storage/async-storage", () => ({
@@ -31,17 +31,12 @@ jest.mock("react-native", () => ({
       optInTracking: jest.fn(),
       optOutTracking: jest.fn(),
       identify: jest.fn().mockResolvedValue(undefined),
-      alias: jest.fn(),
       track: jest.fn(),
-      registerSuperProperties: jest.fn(),
-      registerSuperPropertiesOnce: jest.fn(),
-      unregisterSuperProperty: jest.fn(),
-      getSuperProperties: jest.fn(),
-      clearSuperProperties: jest.fn(),
-      timeEvent: jest.fn(),
-      eventElapsedTime: jest.fn(),
       reset: jest.fn(),
-      getDistinctId: jest.fn(),
+      getVisitorId: jest.fn().mockReturnValue("mock-visitor-id"),
+      updateDefaultEventProperties: jest.fn(),
+      updateDefaultUserCustomProperties: jest.fn(),
+      updateDefaultUserConsentProperties: jest.fn(),
     },
   },
   AppState: {

--- a/__tests__/jest_setup.js
+++ b/__tests__/jest_setup.js
@@ -25,7 +25,6 @@ jest.mock("react-native", () => ({
       setServerURL: jest.fn(),
       setLoggingEnabled: jest.fn(),
       setFlushOnBackground: jest.fn(),
-      setUseIpAddressForGeolocation: jest.fn(),
       setFlushBatchSize: jest.fn(),
       hasOptedOutTracking: jest.fn(),
       optInTracking: jest.fn(),

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -132,10 +132,10 @@ describe("OursPrivacyMain", () => {
     expect(oursprivacyMain.core.initialize).toHaveBeenCalledWith(token);
   });
 
-  it("should override persistent visitor_id when user_id is provided in options", async () => {
-    await oursprivacyMain.initialize(token, false, false, { user_id: "explicit-user-id" }, "https://cdn.oursprivacy.com");
-    expect(oursprivacyMain.oursprivacyPersistent.updateDeviceId).toHaveBeenCalledWith(token, "explicit-user-id");
-    expect(oursprivacyMain.oursprivacyPersistent.updateDistinctId).toHaveBeenCalledWith(token, "explicit-user-id");
+  it("should override persistent visitor_id when visitor_id is provided in options", async () => {
+    await oursprivacyMain.initialize(token, false, false, { visitor_id: "preset-visitor-123" }, "https://cdn.oursprivacy.com");
+    expect(oursprivacyMain.oursprivacyPersistent.updateDeviceId).toHaveBeenCalledWith(token, "preset-visitor-123");
+    expect(oursprivacyMain.oursprivacyPersistent.updateDistinctId).toHaveBeenCalledWith(token, "preset-visitor-123");
     expect(oursprivacyMain.oursprivacyPersistent.persistDeviceId).toHaveBeenCalledWith(token);
     expect(oursprivacyMain.oursprivacyPersistent.persistDistinctId).toHaveBeenCalledWith(token);
   });

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -9,6 +9,16 @@ jest.mock("oursprivacy-react-native/javascript/oursprivacy-core", () => ({
   })),
 }));
 
+jest.mock("oursprivacy-react-native/javascript/oursprivacy-queue", () => ({
+  OursPrivacyQueueManager: {
+    initialize: jest.fn(),
+    enqueue: jest.fn(),
+    getQueue: jest.fn().mockReturnValue([]),
+    spliceQueue: jest.fn(),
+    clearQueue: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
 jest.mock("oursprivacy-react-native/javascript/oursprivacy-network", () => ({
   OursPrivacyNetwork: {
     sendRequest: jest.fn(),
@@ -140,6 +150,37 @@ describe("OursPrivacyMain", () => {
     expect(oursprivacyMain.oursprivacyPersistent.persistDistinctId).toHaveBeenCalledWith(token);
   });
 
+  it("should preserve init options when starting opted out", async () => {
+    await oursprivacyMain.initialize(
+      token,
+      false,
+      true,
+      {
+        visitor_id: "preset-visitor-123",
+        default_event_properties: {platform: "mobile"},
+        default_user_custom_properties: {plan: "pro"},
+        default_user_consent_properties: {marketing: true},
+      },
+      "https://api.oursprivacy.com"
+    );
+
+    expect(oursprivacyMain.config.setServerURL).toHaveBeenCalledWith(
+      token,
+      "https://api.oursprivacy.com"
+    );
+    expect(oursprivacyMain.oursprivacyPersistent.updateOptedOut).toHaveBeenCalledWith(
+      token,
+      true
+    );
+    expect(oursprivacyMain.oursprivacyPersistent.updateDeviceId).toHaveBeenCalledWith(
+      token,
+      "preset-visitor-123"
+    );
+    expect(oursprivacyMain._defaultEventProperties[token]).toEqual({platform: "mobile"});
+    expect(oursprivacyMain._defaultUserCustomProperties[token]).toEqual({plan: "pro"});
+    expect(oursprivacyMain._defaultUserConsentProperties[token]).toEqual({marketing: true});
+  });
+
   it("should not track if initialize with optOutTrackingDefault being true", async () => {
     const trackAutomaticEvents = false;
     const optOutTrackingDefault = true;
@@ -226,6 +267,26 @@ describe("OursPrivacyMain", () => {
     OursPrivacyConfig.getInstance().getLoggingEnabled.mockReturnValueOnce(true);
     await oursprivacyMain.track(token, "test-event");
     expect(console.log).toHaveBeenCalled();
+  });
+
+  it("hasOptedOutTracking should read the persisted opt-out flag", () => {
+    oursprivacyMain.oursprivacyPersistent.getOptedOut.mockReturnValue(true);
+    expect(oursprivacyMain.hasOptedOutTracking(token)).toBe(true);
+    expect(oursprivacyMain.oursprivacyPersistent.getOptedOut).toHaveBeenCalledWith(token);
+  });
+
+  it("optOutTracking should clear queued events before resetting identity", async () => {
+    await oursprivacyMain.optOutTracking(token);
+
+    expect(OursPrivacyQueueManager.clearQueue).toHaveBeenCalledWith(
+      token,
+      OursPrivacyType.EVENTS
+    );
+    expect(oursprivacyMain.oursprivacyPersistent.reset).toHaveBeenCalledWith(token);
+  });
+
+  it("setFlushOnBackground should be a safe no-op in JavaScript mode", () => {
+    expect(() => oursprivacyMain.setFlushOnBackground(token, false)).not.toThrow();
   });
 
   it("should update the identity properties on identify", async () => {

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -76,17 +76,10 @@ jest.mock("oursprivacy-react-native/javascript/oursprivacy-config", () => ({
       setLoggingEnabled: jest.fn(),
       getLoggingEnabled: jest.fn().mockReturnValue(true),
       setServerURL: jest.fn(),
+      setIsManuallySetId: jest.fn(),
     }),
   },
 }));
-
-// jest.mock("oursprivacy-react-native/javascript/oursprivacy-logger", () => {
-//   return {
-//     OursPrivacyLogger: {
-//       log: jest.fn(),
-//     },
-//   };
-// });
 
 const {
   OursPrivacyNetwork,
@@ -126,43 +119,31 @@ describe("OursPrivacyMain", () => {
   it("should initialize properly", async () => {
     const trackAutomaticEvents = false;
     const optOutTrackingDefault = false;
-    const superProperties = {superProp1: "value1", superProp2: "value2"};
+    const options = {default_event_properties: {superProp1: "value1", superProp2: "value2"}};
     const serverURL = "https://api.oursprivacy.com";
 
     await oursprivacyMain.initialize(
       token,
       trackAutomaticEvents,
       optOutTrackingDefault,
-      superProperties,
+      options,
       serverURL
     );
 
     expect(oursprivacyMain.core.initialize).toHaveBeenCalledWith(token);
-
-    expect(
-      oursprivacyMain.oursprivacyPersistent.updateSuperProperties
-    ).toHaveBeenCalledWith(token, {
-      superProp1: "value1",
-      superProp2: "value2",
-      company_id: [222],
-    });
-    expect(
-      oursprivacyMain.oursprivacyPersistent.persistSuperProperties
-    ).toHaveBeenCalledWith(token);
   });
 
   it("should not track if initialize with optOutTrackingDefault being true", async () => {
     const trackAutomaticEvents = false;
     const optOutTrackingDefault = true;
-    const superProperties = {superProp1: "value1", superProp2: "value2"};
+    const options = {};
     const serverURL = "https://api.oursprivacy.com";
-
 
     await oursprivacyMain.initialize(
       token,
       trackAutomaticEvents,
       optOutTrackingDefault,
-      superProperties,
+      options,
       serverURL
     );
 
@@ -181,14 +162,14 @@ describe("OursPrivacyMain", () => {
   it("should track if initialize with optOutTrackingDefault being false", async () => {
     const trackAutomaticEvents = false;
     const optOutTrackingDefault = false;
-    const superProperties = {superProp1: "value1", superProp2: "value2"};
+    const options = {};
     const serverURL = "https://api.oursprivacy.com";
 
     await oursprivacyMain.initialize(
       token,
       trackAutomaticEvents,
       optOutTrackingDefault,
-      superProperties,
+      options,
       serverURL
     );
     oursprivacyMain.setLoggingEnabled(token, true);
@@ -197,79 +178,6 @@ describe("OursPrivacyMain", () => {
 
     await oursprivacyMain.track(token, eventName, eventProperties);
     expect(oursprivacyMain.core.addToOursPrivacyQueue).toHaveBeenCalled();
-  });
-
-  it("register super properties should update properties", async () => {
-    oursprivacyMain.registerSuperProperties(token, {superProp3: "value3"});
-    expect(
-      oursprivacyMain.oursprivacyPersistent.updateSuperProperties
-    ).toHaveBeenCalledWith(token, {
-      superProp1: "value1",
-      superProp2: "value2",
-      superProp3: "value3",
-      company_id: [222],
-    });
-    expect(
-      oursprivacyMain.oursprivacyPersistent.persistSuperProperties
-    ).toHaveBeenCalledWith(token);
-  });
-
-  it("register super properties once should update properties only once", async () => {
-    oursprivacyMain.registerSuperPropertiesOnce(token, {superProp3: "value3"});
-    expect(
-      oursprivacyMain.oursprivacyPersistent.updateSuperProperties
-    ).toHaveBeenCalledWith(token, {
-      superProp1: "value1",
-      superProp2: "value2",
-      superProp3: "value3",
-      company_id: [222],
-    });
-    expect(
-      oursprivacyMain.oursprivacyPersistent.persistSuperProperties
-    ).toHaveBeenCalledWith(token);
-    oursprivacyMain.registerSuperPropertiesOnce(token, {superProp3: "value4"});
-    expect(
-      oursprivacyMain.oursprivacyPersistent.updateSuperProperties
-    ).toHaveBeenCalledWith(token, {
-      superProp1: "value1",
-      superProp2: "value2",
-      superProp3: "value3",
-      company_id: [222],
-    });
-    expect(
-      oursprivacyMain.oursprivacyPersistent.persistSuperProperties
-    ).toHaveBeenCalledWith(token);
-  });
-
-  it("unregister super properties should update properties properly", async () => {
-    oursprivacyMain.registerSuperPropertiesOnce(token, {superProp3: "value3"});
-    expect(
-      oursprivacyMain.oursprivacyPersistent.updateSuperProperties
-    ).toHaveBeenCalledWith(token, {
-      superProp1: "value1",
-      superProp2: "value2",
-      superProp3: "value3",
-      company_id: [222],
-    });
-
-    oursprivacyMain.unregisterSuperProperty(token, "superProp3");
-    expect(
-      oursprivacyMain.oursprivacyPersistent.updateSuperProperties
-    ).toHaveBeenCalledWith(token, {
-      superProp1: "value1",
-      superProp2: "value2",
-      company_id: [222],
-    });
-  });
-
-  it("clear super properties should clear properties properly", async () => {
-    oursprivacyMain.clearSuperProperties(token);
-    expect(
-      oursprivacyMain.oursprivacyPersistent.updateSuperProperties
-    ).toHaveBeenCalledWith(token, {});
-    expect(
-      oursprivacyMain.oursprivacyPersistent.persistSuperProperties
-    ).toHaveBeenCalledWith(token);
   });
 
   it("should send correct payload on track event", async () => {
@@ -282,16 +190,16 @@ describe("OursPrivacyMain", () => {
       OursPrivacyType.EVENTS,
       expect.objectContaining({
         event: eventName,
-        properties: expect.objectContaining({
-          token: token,
-          time: expect.any(Number),
+        visitor_id: "device-id-mock",
+        distinct_id: expect.any(String),
+        eventProperties: expect.objectContaining({
           prop1: "value1",
           prop2: "value2",
-          $device_id: "device-id-mock",
-          $user_id: "user-id-mock",
-          distinct_id: "distinct-id-mock",
-          superProp1: "value1", // include super properties
-          superProp2: "value2",
+        }),
+        defaultProperties: expect.objectContaining({
+          device_type: "mobile",
+          os_name: expect.any(String),
+          version: expect.any(String),
         }),
       })
     );
@@ -311,25 +219,6 @@ describe("OursPrivacyMain", () => {
     OursPrivacyConfig.getInstance().getLoggingEnabled.mockReturnValueOnce(true);
     await oursprivacyMain.track(token, "test-event");
     expect(console.log).toHaveBeenCalled();
-  });
-
-  it("timeEvent should work as expected", async () => {
-    oursprivacyMain.timeEvent(token, "test-event");
-    expect(
-      oursprivacyMain.oursprivacyPersistent.updateTimeEvents
-    ).toHaveBeenCalledWith(token, {"test-event": expect.any(Number)});
-    expect(
-      oursprivacyMain.oursprivacyPersistent.persistTimeEvents
-    ).toHaveBeenCalledWith(token);
-  });
-
-  it("eventElapsedTime should work as expected", async () => {
-    oursprivacyMain.timeEvent(token, "test-event");
-    const elapsedTime = await oursprivacyMain.eventElapsedTime(
-      token,
-      "test-event"
-    );
-    expect(elapsedTime).toBeGreaterThan(0);
   });
 
   it("should update the identity properties on identify", async () => {
@@ -356,479 +245,79 @@ describe("OursPrivacyMain", () => {
     );
   });
 
-  it("should send correct payload on set profile properties", async () => {
-    const properties = {prop1: "value1", prop2: "value2"};
-
-    await oursprivacyMain.set(token, properties);
-
-    expect(oursprivacyMain.core.addToOursPrivacyQueue).toHaveBeenCalledWith(
-      token,
-      OursPrivacyType.USER,
-      expect.objectContaining({
-        $token: token,
-        $time: expect.any(Number),
-        $set: {prop1: "value1", prop2: "value2"},
-        $distinct_id: "distinct-id-mock",
-        $device_id: "device-id-mock",
-        $user_id: "user-id-mock",
-      })
-    );
-  });
-
-  it("should send correct payload on setOnce profile properties", async () => {
-    const properties = {prop1: "value1", prop2: "value2"};
-
-    await oursprivacyMain.setOnce(token, properties);
-
-    expect(oursprivacyMain.core.addToOursPrivacyQueue).toHaveBeenCalledWith(
-      token,
-      OursPrivacyType.USER,
-      expect.objectContaining({
-        $token: token,
-        $time: expect.any(Number),
-        $set_once: {prop1: "value1", prop2: "value2"},
-        $distinct_id: "distinct-id-mock",
-        $device_id: "device-id-mock",
-        $user_id: "user-id-mock",
-      })
-    );
-  });
-
-  it("should send correct payload on increment profile properties", async () => {
-    const properties = {prop1: 3};
-
-    await oursprivacyMain.increment(token, properties);
-
-    expect(oursprivacyMain.core.addToOursPrivacyQueue).toHaveBeenCalledWith(
-      token,
-      OursPrivacyType.USER,
-      expect.objectContaining({
-        $token: token,
-        $time: expect.any(Number),
-        $add: {prop1: 3},
-        $distinct_id: "distinct-id-mock",
-        $device_id: "device-id-mock",
-        $user_id: "user-id-mock",
-      })
-    );
-  });
-
-  it("should send correct payload on append profile properties", async () => {
-    const properties = {prop1: "value1"};
-
-    await oursprivacyMain.append(token, properties);
-
-    expect(oursprivacyMain.core.addToOursPrivacyQueue).toHaveBeenCalledWith(
-      token,
-      OursPrivacyType.USER,
-      expect.objectContaining({
-        $token: token,
-        $time: expect.any(Number),
-        $append: {prop1: "value1"},
-        $distinct_id: "distinct-id-mock",
-        $device_id: "device-id-mock",
-        $user_id: "user-id-mock",
-      })
-    );
-
-    await oursprivacyMain.append(token, "testProp", "testValue");
-
-    expect(oursprivacyMain.core.addToOursPrivacyQueue).toHaveBeenCalledWith(
-      token,
-      OursPrivacyType.USER,
-      expect.objectContaining({
-        $token: token,
-        $time: expect.any(Number),
-        $append: {testProp: "testValue"},
-        $distinct_id: "distinct-id-mock",
-        $device_id: "device-id-mock",
-        $user_id: "user-id-mock",
-      })
-    );
-  });
-
-  it("should send correct payload on union profile properties", async () => {
-    const properties = {prop1: "value1"};
-
-    await oursprivacyMain.union(token, properties);
-
-    expect(oursprivacyMain.core.addToOursPrivacyQueue).toHaveBeenCalledWith(
-      token,
-      OursPrivacyType.USER,
-      expect.objectContaining({
-        $token: token,
-        $time: expect.any(Number),
-        $union: {prop1: "value1"},
-        $distinct_id: "distinct-id-mock",
-        $device_id: "device-id-mock",
-        $user_id: "user-id-mock",
-      })
-    );
-
-    await oursprivacyMain.union(token, "testProp", "testValue");
-
-    expect(oursprivacyMain.core.addToOursPrivacyQueue).toHaveBeenCalledWith(
-      token,
-      OursPrivacyType.USER,
-      expect.objectContaining({
-        $token: token,
-        $time: expect.any(Number),
-        $union: {testProp: "testValue"},
-        $distinct_id: "distinct-id-mock",
-        $device_id: "device-id-mock",
-        $user_id: "user-id-mock",
-      })
-    );
-  });
-
-  it("should send correct payload on remove profile properties", async () => {
-    const properties = {prop1: "value1"};
-
-    await oursprivacyMain.remove(token, properties);
-
-    expect(oursprivacyMain.core.addToOursPrivacyQueue).toHaveBeenCalledWith(
-      token,
-      OursPrivacyType.USER,
-      expect.objectContaining({
-        $token: token,
-        $time: expect.any(Number),
-        $remove: {prop1: "value1"},
-        $distinct_id: "distinct-id-mock",
-        $device_id: "device-id-mock",
-        $user_id: "user-id-mock",
-      })
-    );
-
-    await oursprivacyMain.remove(token, "testProp", "testValue");
-
-    expect(oursprivacyMain.core.addToOursPrivacyQueue).toHaveBeenCalledWith(
-      token,
-      OursPrivacyType.USER,
-      expect.objectContaining({
-        $token: token,
-        $time: expect.any(Number),
-        $remove: {testProp: "testValue"},
-        $distinct_id: "distinct-id-mock",
-        $device_id: "device-id-mock",
-        $user_id: "user-id-mock",
-      })
-    );
-  });
-
-  it("should send correct payload on trackCharge", async () => {
-    const properties = {prop1: "value1"};
-    const charge = 100;
-
-    await oursprivacyMain.trackCharge(token, charge, properties);
-
-    expect(oursprivacyMain.core.addToOursPrivacyQueue).toHaveBeenCalledWith(
-      token,
-      OursPrivacyType.USER,
-      expect.objectContaining({
-        $token: token,
-        $time: expect.any(Number),
-        $append: {
-          $transactions: {
-            $amount: 100,
-            $time: expect.any(Number),
-            prop1: "value1",
-          },
-        },
-        $distinct_id: "distinct-id-mock",
-        $device_id: "device-id-mock",
-        $user_id: "user-id-mock",
-      })
-    );
-  });
-
-  it("should send correct payload on clearCharge", async () => {
-    await oursprivacyMain.clearCharges(token);
-
-    expect(oursprivacyMain.core.addToOursPrivacyQueue).toHaveBeenCalledWith(
-      token,
-      OursPrivacyType.USER,
-      expect.objectContaining({
-        $token: token,
-        $time: expect.any(Number),
-        $set: {
-          $transactions: [],
-        },
-        $distinct_id: "distinct-id-mock",
-        $device_id: "device-id-mock",
-        $user_id: "user-id-mock",
-      })
-    );
-  });
-
-  it("should send correct payload on unset profile properties", async () => {
-    const property = "prop1";
-
-    await oursprivacyMain.unset(token, property);
-
-    expect(oursprivacyMain.core.addToOursPrivacyQueue).toHaveBeenCalledWith(
-      token,
-      OursPrivacyType.USER,
-      expect.objectContaining({
-        $token: token,
-        $time: expect.any(Number),
-        $unset: [property],
-        $distinct_id: "distinct-id-mock",
-        $device_id: "device-id-mock",
-        $user_id: "user-id-mock",
-      })
-    );
-  });
-
-  it("should send correct payload on delete profile", async () => {
-    await oursprivacyMain.deleteUser(token);
-    expect(oursprivacyMain.core.addToOursPrivacyQueue).toHaveBeenCalledWith(
-      token,
-      OursPrivacyType.USER,
-      expect.objectContaining({
-        $token: token,
-        $time: expect.any(Number),
-        $delete: "null",
-        $distinct_id: "distinct-id-mock",
-        $device_id: "device-id-mock",
-        $user_id: "user-id-mock",
-      })
-    );
-  });
-
-  it("should send correct payload on trackWithGroups", async () => {
-    const properties = {prop1: "value1"};
-    const eventName = "event1";
-    const groups = {company_id: 111};
-    await oursprivacyMain.trackWithGroups(token, eventName, properties, groups);
-
+  it("should send correct $identify payload on identify", async () => {
+    const newDistinctId = "new-distinct-id";
+    await oursprivacyMain.identify(token, newDistinctId);
     expect(oursprivacyMain.core.addToOursPrivacyQueue).toHaveBeenCalledWith(
       token,
       OursPrivacyType.EVENTS,
       expect.objectContaining({
-        event: "event1",
-        properties: expect.objectContaining({
-          token: token,
-          time: expect.any(Number),
-          prop1: "value1",
-          $device_id: "device-id-mock",
-          $user_id: "user-id-mock",
-          distinct_id: "distinct-id-mock",
-          superProp1: "value1", // include super properties
-          superProp2: "value2",
-          company_id: 111,
+        event: "$identify",
+        visitor_id: "device-id-mock",
+        distinct_id: expect.any(String),
+        eventProperties: null,
+        userProperties: expect.objectContaining({
+          external_id: newDistinctId,
+        }),
+        defaultProperties: expect.objectContaining({
+          device_type: "mobile",
         }),
       })
     );
   });
 
-  it("should send correct payload on addGroup", async () => {
-    await oursprivacyMain.addGroup(token, "company_id", 111);
-
+  it("updateDefaultEventProperties should merge into event payload", async () => {
+    oursprivacyMain.updateDefaultEventProperties(token, {tier: "pro"});
+    await oursprivacyMain.track(token, "Test Event", {});
     expect(oursprivacyMain.core.addToOursPrivacyQueue).toHaveBeenCalledWith(
       token,
-      OursPrivacyType.USER,
+      OursPrivacyType.EVENTS,
       expect.objectContaining({
-        $token: token,
-        $time: expect.any(Number),
-        $union: {company_id: [111]},
-        $distinct_id: "distinct-id-mock",
-        $device_id: "device-id-mock",
-        $user_id: "user-id-mock",
-      })
-    );
-
-    expect(
-      oursprivacyMain.oursprivacyPersistent.updateSuperProperties
-    ).toHaveBeenCalledWith(token, {
-      company_id: [222, 111],
-      superProp1: "value1",
-      superProp2: "value2",
-    });
-    expect(
-      oursprivacyMain.oursprivacyPersistent.persistSuperProperties
-    ).toHaveBeenCalledWith(token);
-  });
-
-  it("should send correct payload on setGroup", async () => {
-    await oursprivacyMain.setGroup(token, "company_id", 333);
-
-    expect(oursprivacyMain.core.addToOursPrivacyQueue).toHaveBeenCalledWith(
-      token,
-      OursPrivacyType.USER,
-      expect.objectContaining({
-        $token: token,
-        $time: expect.any(Number),
-        $set: {company_id: [333]},
-        $distinct_id: "distinct-id-mock",
-        $device_id: "device-id-mock",
-        $user_id: "user-id-mock",
-      })
-    );
-
-    expect(
-      oursprivacyMain.oursprivacyPersistent.updateSuperProperties
-    ).toHaveBeenCalledWith(token, {
-      company_id: [333],
-      superProp1: "value1",
-      superProp2: "value2",
-    });
-    expect(
-      oursprivacyMain.oursprivacyPersistent.persistSuperProperties
-    ).toHaveBeenCalledWith(token);
-  });
-
-  it("should send correct payload on removeGroup", async () => {
-    await oursprivacyMain.addGroup(token, "company_id", 111);
-    // The company id has been added
-    expect(
-      oursprivacyMain.oursprivacyPersistent.updateSuperProperties
-    ).toHaveBeenCalledWith(token, {
-      company_id: [222, 111],
-      superProp1: "value1",
-      superProp2: "value2",
-    });
-    expect(
-      oursprivacyMain.oursprivacyPersistent.persistSuperProperties
-    ).toHaveBeenCalledWith(token);
-
-    await oursprivacyMain.removeGroup(token, "company_id", 111);
-    expect(oursprivacyMain.core.addToOursPrivacyQueue).toHaveBeenCalledWith(
-      token,
-      OursPrivacyType.USER,
-      expect.objectContaining({
-        $token: token,
-        $time: expect.any(Number),
-        $remove: {company_id: 111},
-        $distinct_id: "distinct-id-mock",
-        $device_id: "device-id-mock",
-        $user_id: "user-id-mock",
-      })
-    );
-
-    // The company id has been removed
-    expect(
-      oursprivacyMain.oursprivacyPersistent.updateSuperProperties
-    ).toHaveBeenCalledWith(token, {
-      company_id: [222],
-      superProp1: "value1",
-      superProp2: "value2",
-    });
-    expect(
-      oursprivacyMain.oursprivacyPersistent.persistSuperProperties
-    ).toHaveBeenCalledWith(token);
-  });
-
-  it("should send correct payload on deleteGroup", async () => {
-    await oursprivacyMain.deleteGroup(token);
-    expect(oursprivacyMain.core.addToOursPrivacyQueue).toHaveBeenCalledWith(
-      token,
-      OursPrivacyType.GROUPS,
-      expect.objectContaining({
-        $token: token,
-        $time: expect.any(Number),
-        $delete: "null",
+        eventProperties: expect.objectContaining({tier: "pro"}),
       })
     );
   });
 
-  it("should send correct payload on group set", async () => {
-    const properties = {prop1: "value1", prop2: "value2"};
-
-    await oursprivacyMain.groupSetProperties(token, "company_id", 444, properties);
-
+  it("updateDefaultUserCustomProperties should appear in userProperties", async () => {
+    oursprivacyMain.updateDefaultUserCustomProperties(token, {plan: "enterprise"});
+    await oursprivacyMain.track(token, "Test Event", {});
     expect(oursprivacyMain.core.addToOursPrivacyQueue).toHaveBeenCalledWith(
       token,
-      OursPrivacyType.GROUPS,
+      OursPrivacyType.EVENTS,
       expect.objectContaining({
-        $token: token,
-        $time: expect.any(Number),
-        $group_id: 444,
-        $group_key: "company_id",
-        $set: {prop1: "value1", prop2: "value2"},
+        userProperties: expect.objectContaining({
+          custom_properties: expect.objectContaining({plan: "enterprise"}),
+        }),
       })
     );
   });
 
-  it("should send correct payload on group set once", async () => {
-    const properties = {prop1: "value1", prop2: "value2"};
-
-    await oursprivacyMain.groupSetPropertyOnce(
-      token,
-      "company_id",
-      444,
-      properties
-    );
-
+  it("updateDefaultUserConsentProperties should appear in userProperties", async () => {
+    oursprivacyMain.updateDefaultUserConsentProperties(token, {marketing: true});
+    await oursprivacyMain.track(token, "Test Event", {});
     expect(oursprivacyMain.core.addToOursPrivacyQueue).toHaveBeenCalledWith(
       token,
-      OursPrivacyType.GROUPS,
+      OursPrivacyType.EVENTS,
       expect.objectContaining({
-        $token: token,
-        $time: expect.any(Number),
-        $group_id: 444,
-        $group_key: "company_id",
-        $set_once: {prop1: "value1", prop2: "value2"},
+        userProperties: expect.objectContaining({
+          consent: expect.objectContaining({marketing: true}),
+        }),
       })
     );
   });
 
-  it("should send correct payload on groupUnsetProperty", async () => {
-    await oursprivacyMain.groupUnsetProperty(token, "company_id", 444, "prop1");
-
-    expect(oursprivacyMain.core.addToOursPrivacyQueue).toHaveBeenCalledWith(
-      token,
-      OursPrivacyType.GROUPS,
-      expect.objectContaining({
-        $token: token,
-        $time: expect.any(Number),
-        $group_id: 444,
-        $group_key: "company_id",
-        $unset: ["prop1"],
-      })
-    );
+  it("getVisitorId should return the device id", () => {
+    const visitorId = oursprivacyMain.getVisitorId(token);
+    expect(visitorId).toBe("device-id-mock");
   });
 
-  it("should send correct payload on groupRemovePropertyValue", async () => {
-    await oursprivacyMain.groupRemovePropertyValue(
-      token,
-      "company_id",
-      444,
-      "prop1",
-      "value1"
-    );
-
-    expect(oursprivacyMain.core.addToOursPrivacyQueue).toHaveBeenCalledWith(
-      token,
-      OursPrivacyType.GROUPS,
-      expect.objectContaining({
-        $token: token,
-        $time: expect.any(Number),
-        $group_id: 444,
-        $group_key: "company_id",
-        $remove: {prop1: "value1"},
-      })
-    );
-  });
-
-  it("should send correct payload on groupUnionProperty", async () => {
-    await oursprivacyMain.groupUnionProperty(
-      token,
-      "company_id",
-      444,
-      "prop1",
-      "value1"
-    );
-
-    expect(oursprivacyMain.core.addToOursPrivacyQueue).toHaveBeenCalledWith(
-      token,
-      OursPrivacyType.GROUPS,
-      expect.objectContaining({
-        $token: token,
-        $time: expect.any(Number),
-        $group_id: 444,
-        $group_key: "company_id",
-        $union: {prop1: "value1"},
-      })
-    );
+  it("reset should clear default property maps", async () => {
+    oursprivacyMain.updateDefaultEventProperties(token, {foo: "bar"});
+    oursprivacyMain.updateDefaultUserCustomProperties(token, {plan: "pro"});
+    oursprivacyMain.updateDefaultUserConsentProperties(token, {marketing: true});
+    await oursprivacyMain.reset(token);
+    expect(oursprivacyMain._defaultEventProperties[token]).toEqual({});
+    expect(oursprivacyMain._defaultUserCustomProperties[token]).toEqual({});
+    expect(oursprivacyMain._defaultUserConsentProperties[token]).toEqual({});
   });
 });

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -72,7 +72,6 @@ jest.mock("oursprivacy-react-native/javascript/oursprivacy-config", () => ({
       getFlushInterval: jest.fn().mockReturnValue(1000),
       getFlushBatchSize: jest.fn().mockReturnValue(50),
       getServerURL: jest.fn(),
-      getUseIpAddressForGeolocation: jest.fn(),
       setLoggingEnabled: jest.fn(),
       getLoggingEnabled: jest.fn().mockReturnValue(true),
       setServerURL: jest.fn(),
@@ -131,6 +130,14 @@ describe("OursPrivacyMain", () => {
     );
 
     expect(oursprivacyMain.core.initialize).toHaveBeenCalledWith(token);
+  });
+
+  it("should override persistent visitor_id when user_id is provided in options", async () => {
+    await oursprivacyMain.initialize(token, false, false, { user_id: "explicit-user-id" }, "https://cdn.oursprivacy.com");
+    expect(oursprivacyMain.oursprivacyPersistent.updateDeviceId).toHaveBeenCalledWith(token, "explicit-user-id");
+    expect(oursprivacyMain.oursprivacyPersistent.updateDistinctId).toHaveBeenCalledWith(token, "explicit-user-id");
+    expect(oursprivacyMain.oursprivacyPersistent.persistDeviceId).toHaveBeenCalledWith(token);
+    expect(oursprivacyMain.oursprivacyPersistent.persistDistinctId).toHaveBeenCalledWith(token);
   });
 
   it("should not track if initialize with optOutTrackingDefault being true", async () => {

--- a/__tests__/network.test.js
+++ b/__tests__/network.test.js
@@ -15,32 +15,89 @@ afterEach(() => {
 
 describe("OursPrivacyNetwork", () => {
   const mockToken = "test-token";
-  const mockEndpoint = "/track";
-  const mockServerURL = "https://api.oursprivacy.com";
-  const mockData = { event: "testEvent" };
-  const useIPAddressForGeoLocation = true;
+  const mockEndpoint = "/ingest";
+  const mockServerURL = "https://cdn.oursprivacy.com";
+  const mockData = [
+    {
+      event: "Purchase",
+      visitor_id: "uuid-123",
+      distinct_id: "per-event-uuid",
+      eventProperties: { price: 99 },
+      userProperties: null,
+      defaultProperties: { device_type: "mobile", os_name: "iOS", version: "1.1.0" },
+    },
+  ];
 
   it("sends a successful request", async () => {
-    fetchMock.mockResponseOnce(JSON.stringify({}), { status: 200 });
+    fetchMock.mockResponseOnce(JSON.stringify({ success: true, visitor_id: "abc" }), { status: 200 });
 
     await OursPrivacyNetwork.sendRequest({
       token: mockToken,
       endpoint: mockEndpoint,
       data: mockData,
       serverURL: mockServerURL,
-      useIPAddressForGeoLocation,
     });
 
     expect(fetchMock).toHaveBeenCalledWith(
-      expect.stringContaining(mockServerURL + mockEndpoint),
+      `${mockServerURL}${mockEndpoint}`,
       expect.anything()
     );
+  });
+
+  it("sends JSON body with token, is_manually_set_id, and data", async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ success: true }), { status: 200 });
+
+    await OursPrivacyNetwork.sendRequest({
+      token: mockToken,
+      endpoint: mockEndpoint,
+      data: mockData,
+      serverURL: mockServerURL,
+      isManuallySetId: false,
+    });
+
+    const [, options] = fetchMock.mock.calls[0];
+    expect(options.headers["Content-Type"]).toBe("application/json");
+    const body = JSON.parse(options.body);
+    expect(body.token).toBe(mockToken);
+    expect(body.is_manually_set_id).toBe(false);
+    expect(body.data).toEqual(mockData);
+  });
+
+  it("sets is_manually_set_id: true when provided", async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ success: true }), { status: 200 });
+
+    await OursPrivacyNetwork.sendRequest({
+      token: mockToken,
+      endpoint: mockEndpoint,
+      data: mockData,
+      serverURL: mockServerURL,
+      isManuallySetId: true,
+    });
+
+    const [, options] = fetchMock.mock.calls[0];
+    const body = JSON.parse(options.body);
+    expect(body.is_manually_set_id).toBe(true);
+  });
+
+  it("does not include ?ip= query param in the URL", async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ success: true }), { status: 200 });
+
+    await OursPrivacyNetwork.sendRequest({
+      token: mockToken,
+      endpoint: mockEndpoint,
+      data: mockData,
+      serverURL: mockServerURL,
+    });
+
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).not.toContain("?ip=");
+    expect(url).toBe(`${mockServerURL}${mockEndpoint}`);
   });
 
   it("retries on failure and succeeds", async () => {
     fetchMock.mockResponses(
       [JSON.stringify({}), { status: 500 }],
-      [JSON.stringify({}), { status: 200 }]
+      [JSON.stringify({ success: true }), { status: 200 }]
     );
 
     await OursPrivacyNetwork.sendRequest({
@@ -48,7 +105,6 @@ describe("OursPrivacyNetwork", () => {
       endpoint: mockEndpoint,
       data: mockData,
       serverURL: mockServerURL,
-      useIPAddressForGeoLocation,
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
@@ -63,10 +119,8 @@ describe("OursPrivacyNetwork", () => {
         endpoint: mockEndpoint,
         data: mockData,
         serverURL: mockServerURL,
-        useIPAddressForGeoLocation,
       })
     ).rejects.toThrow();
-    // Assert fetch was called exactly once, indicating no retry was attempted
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,7 +24,7 @@ android {
         minSdkVersion 24
         targetSdkVersion 34
         versionCode 1
-        versionName "1.1.0"
+        versionName "1.2.0"
     }
     lintOptions {
         abortOnError true

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,7 @@ export type OursPrivacyAsyncStorage = {
 
 export type OursPrivacyInitOptions = {
   serverURL?: string;
-  user_id?: string;
+  visitor_id?: string;
   default_event_properties?: Record<string, any>;
   default_user_custom_properties?: Record<string, any>;
   default_user_consent_properties?: Record<string, any>;
@@ -45,7 +45,7 @@ export class OursPrivacy {
   hasOptedOutTracking(): Promise<boolean>;
   optInTracking(): void;
   optOutTracking(): void;
-  identify(distinctId: string, userProperties?: OursPrivacyUserProperties): Promise<void>;
+  identify(id: string, userProperties?: OursPrivacyUserProperties): Promise<void>;
   track(eventName: string, properties?: OursPrivacyProperties): void;
   reset(): void;
   getVisitorId(): string | null;

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,24 @@ export type OursPrivacyAsyncStorage = {
   removeItem(key: string): Promise<void>;
 };
 
+export type OursPrivacyInitOptions = {
+  serverURL?: string;
+  user_id?: string;
+  default_event_properties?: Record<string, any>;
+  default_user_custom_properties?: Record<string, any>;
+  default_user_consent_properties?: Record<string, any>;
+};
+
+export type OursPrivacyUserProperties = {
+  email?: string;
+  external_id?: string;
+  phone_number?: string;
+  first_name?: string;
+  last_name?: string;
+  custom_properties?: Record<string, any>;
+  consent?: Record<string, any>;
+};
+
 export class OursPrivacy {
   constructor(token: string, trackAutoMaticEvents: boolean);
   constructor(token: string, trackAutoMaticEvents: boolean, useNative: true);
@@ -16,15 +34,9 @@ export class OursPrivacy {
     useNative: false,
     storage?: OursPrivacyAsyncStorage
   );
-  static init(
-    token: string,
-    trackAutomaticEvents: boolean,
-    optOutTrackingDefault?: boolean
-  ): Promise<OursPrivacy>;
   init(
     optOutTrackingDefault?: boolean,
-    superProperties?: OursPrivacyProperties,
-    serverURL?: String
+    options?: OursPrivacyInitOptions
   ): Promise<void>;
   setServerURL(serverURL: string): void;
   setLoggingEnabled(loggingEnabled: boolean): void;
@@ -34,18 +46,12 @@ export class OursPrivacy {
   hasOptedOutTracking(): Promise<boolean>;
   optInTracking(): void;
   optOutTracking(): void;
-  identify(distinctId: string, userProperties?: any): Promise<void>;
-  alias(alias: string, distinctId: string): void;
+  identify(distinctId: string, userProperties?: OursPrivacyUserProperties): Promise<void>;
   track(eventName: string, properties?: OursPrivacyProperties): void;
-  registerSuperProperties(properties: OursPrivacyProperties): void;
-  registerSuperPropertiesOnce(properties: OursPrivacyProperties): void;
-  unregisterSuperProperty(propertyName: string): void;
-  getSuperProperties(): Promise<OursPrivacyProperties>;
-  clearSuperProperties(): void;
-  timeEvent(eventName: string): void;
-  eventElapsedTime(eventName: string): Promise<number>;
   reset(): void;
-  getDistinctId(): Promise<string>;
-  getDeviceId(): Promise<string>;
+  getVisitorId(): string | null;
+  updateDefaultEventProperties(properties: Record<string, any>): void;
+  updateDefaultUserCustomProperties(properties: Record<string, any>): void;
+  updateDefaultUserConsentProperties(properties: Record<string, any>): void;
   flush(): void;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -41,7 +41,6 @@ export class OursPrivacy {
   setServerURL(serverURL: string): void;
   setLoggingEnabled(loggingEnabled: boolean): void;
   setFlushOnBackground(flushOnBackground: boolean): void;
-  setUseIpAddressForGeolocation(useIpAddressForGeolocation: boolean): void;
   setFlushBatchSize(flushBatchSize: number): void;
   hasOptedOutTracking(): Promise<boolean>;
   optInTracking(): void;

--- a/index.js
+++ b/index.js
@@ -111,21 +111,6 @@ export class OursPrivacy {
     }
   }
 
-  /**
-   * This controls whether to automatically send the client IP Address as part of event tracking.
-   * With an IP address, geo-location is possible down to neighborhoods within a city,
-   * although the OursPrivacy Dashboard will just show you city level location specificity.
-   *
-   * @param {boolean} useIpAddressForGeolocation whether to automatically send the client IP Address.
-   * Defaults to true.
-   *
-   */
-  setUseIpAddressForGeolocation(useIpAddressForGeolocation) {
-    this.oursprivacyImpl.setUseIpAddressForGeolocation(
-      this.token,
-      useIpAddressForGeolocation
-    );
-  }
 
   /**
    * Set the number of events sent in a single network request to the OursPrivacy server.

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 "use strict";
 
-import {Platform, NativeModules} from "react-native";
-const {OursPrivacyReactNative} = NativeModules;
+import {Platform} from "react-native";
 import OursPrivacyMain from "./javascript/oursprivacy-main"
 
 const ERROR_MESSAGE = {
@@ -11,7 +10,7 @@ const ERROR_MESSAGE = {
 
 const PARAMS = {
   TOKEN: "token",
-  DISTINCT_ID: "distinctId",
+  ID: "id",
   EVENT_NAME: "eventName",
   PROPERTIES: "properties",
 };
@@ -20,6 +19,10 @@ const DEFAULT_OPT_OUT = false;
 
 /**
  * The primary class for integrating OursPrivacy with your app.
+ *
+ * Always uses the JavaScript implementation regardless of the useNative argument.
+ * The native iOS/Android modules (forked from Mixpanel) generate a payload format
+ * that does not match the Ours Privacy ingest schema, so they are not used.
  */
 export class OursPrivacy {
   constructor(token, trackAutomaticEvents, useNative = true, storage) {
@@ -31,122 +34,63 @@ export class OursPrivacy {
     }
     this.token = token;
     this.trackAutomaticEvents = trackAutomaticEvents;
-
-    if (useNative && OursPrivacyReactNative) {
-      this._isNative = true;
-      this.oursprivacyImpl = OursPrivacyReactNative;
-      // JS-side state for methods the native bridge doesn't export
-      this._visitorId = null;
-      this._isManuallySetId = false;
-      this._defaultUserCustomProperties = {};
-      this._defaultUserConsentProperties = {};
-      return;
-    } else if (useNative) {
-      console.warn(
-        "OursPrivacyReactNative is not available; using JavaScript mode. If you prefer not to use the JavaScript mode, please follow the guide in the GitHub repository: https://github.com/oursprivacy/oursprivacy-react-native."
-      );
-    }
-
-    this._isNative = false;
     this.oursprivacyImpl = new OursPrivacyMain(token, trackAutomaticEvents, storage);
   }
 
   /**
-   * Initializes OursPrivacy
+   * Initializes OursPrivacy.
    *
-   * @param {boolean} optOutTrackingDefault Optional Whether or not OursPrivacy can start tracking by default. See optOutTracking()
-   * @param {object} options Optional Options object. Supports:
-   *   - serverURL: string
-   *   - user_id: string
-   *   - default_event_properties: object
-   *   - default_user_custom_properties: object
-   *   - default_user_consent_properties: object
-   *
+   * @param {boolean} optOutTrackingDefault Whether to start tracking opted-out. Defaults to false.
+   * @param {object} options Optional configuration:
+   *   - serverURL: string — override the ingest endpoint
+   *   - visitor_id: string — pre-set the visitor ID (sets is_manually_set_id: true)
+   *   - default_event_properties: object — merged into every track() call
+   *   - default_user_custom_properties: object — merged into userProperties.custom_properties
+   *   - default_user_consent_properties: object — merged into userProperties.consent
    */
   async init(
     optOutTrackingDefault = DEFAULT_OPT_OUT,
     options = {}
   ) {
     const serverURL = (options && options.serverURL) || "https://cdn.oursprivacy.com";
-    if (this._isNative) {
-      // Native bridge initialize() expects a flat super-properties map as the 4th
-      // argument. Passing our options object directly would send keys like
-      // default_event_properties as literal super-properties and silently ignore
-      // user_id. Pass an empty map and handle each option explicitly below.
-      await this.oursprivacyImpl.initialize(
-        this.token,
-        this.trackAutomaticEvents,
-        optOutTrackingDefault,
-        {},
-        serverURL
-      );
-      if (options) {
-        if (options.default_event_properties) {
-          await this.oursprivacyImpl.registerSuperProperties(
-            this.token,
-            options.default_event_properties
-          );
-        }
-        if (options.user_id) {
-          this._isManuallySetId = true;
-          this._visitorId = options.user_id;
-        }
-        if (options.default_user_custom_properties) {
-          Object.assign(this._defaultUserCustomProperties, options.default_user_custom_properties);
-        }
-        if (options.default_user_consent_properties) {
-          Object.assign(this._defaultUserConsentProperties, options.default_user_consent_properties);
-        }
-      }
-      // Cache the native device ID so getVisitorId() can return synchronously
-      if (!this._visitorId) {
-        this._visitorId = await this.oursprivacyImpl.getDeviceId(this.token);
-      }
-    } else {
-      await this.oursprivacyImpl.initialize(
-        this.token,
-        this.trackAutomaticEvents,
-        optOutTrackingDefault,
-        options,
-        serverURL
-      );
-    }
+    await this.oursprivacyImpl.initialize(
+      this.token,
+      this.trackAutomaticEvents,
+      optOutTrackingDefault,
+      options,
+      serverURL
+    );
   }
 
   /**
    * Set the base URL used for OursPrivacy API requests.
-   * Useful if you need to proxy OursPrivacy requests. Defaults to https://cdn.oursprivacy.com.
-   * To route data to OursPrivacy's EU servers, set to https://api-eu.oursprivacy.com
+   * Defaults to https://cdn.oursprivacy.com.
+   * To route data to OursPrivacy's EU servers, set to https://api-eu.oursprivacy.com.
    *
    * @param {string} serverURL the base URL used for OursPrivacy API requests
-   *
    */
   setServerURL(serverURL) {
     this.oursprivacyImpl.setServerURL(this.token, serverURL);
   }
 
   /**
-   * This allows enabling or disabling of all OursPrivacy logs at run time.
-   * All logging is disabled by default. Usually, this is only required if
-   * you are running into issues with the SDK that you want to debug
+   * Enable or disable debug logging at run time. Disabled by default.
    *
    * @param {boolean} loggingEnabled whether to enable logging
-   *
    */
   setLoggingEnabled(loggingEnabled) {
     this.oursprivacyImpl.setLoggingEnabled(this.token, loggingEnabled);
   }
 
   /**
-   * This allows enabling or disabling whether or not OursPrivacy flushes events
-   * when the app enters the background on iOS. This is set to true by default.
+   * Control whether OursPrivacy flushes queued events when the app enters the
+   * background on iOS. Enabled by default.
    *
-   * @param {boolean} flushOnBackground whether to enable logging
-   *
+   * @param {boolean} flushOnBackground
    */
   setFlushOnBackground(flushOnBackground) {
     if (Platform.OS === "ios") {
-      OursPrivacyReactNative.setFlushOnBackground(this.token, flushOnBackground);
+      this.oursprivacyImpl.setFlushOnBackground(this.token, flushOnBackground);
     } else {
       console.warn(
         "OursPrivacy setFlushOnBackground was called and ignored because this method only works on iOS."
@@ -154,66 +98,57 @@ export class OursPrivacy {
     }
   }
 
-
   /**
-   * Set the number of events sent in a single network request to the OursPrivacy server.
-   * By configuring this value, you can optimize network usage and manage the frequency of communication between the client and the server. The maximum size is 50; any value over 50 will default to 50.
+   * Set the maximum number of events sent in a single network request.
+   * Values above 50 are clamped to 50.
    *
-   * @param {integer} flushBatchSize whether to automatically send the client IP Address.
-   * Defaults to true.
-   *
+   * @param {integer} flushBatchSize
    */
   setFlushBatchSize(flushBatchSize) {
     this.oursprivacyImpl.setFlushBatchSize(this.token, flushBatchSize);
   }
 
   /**
-   * Will return true if the user has opted out from tracking.
+   * Returns true if the visitor has opted out from tracking.
    *
-   * @return {Promise<boolean>} true if user has opted out from tracking. Defaults to false.
+   * @return {Promise<boolean>}
    */
   hasOptedOutTracking() {
     return this.oursprivacyImpl.hasOptedOutTracking(this.token);
   }
 
   /**
-   * Use this method to opt-in an already opted-out user from tracking. People updates and track
-   * calls will be sent to OursPrivacy after using this method.
-   * This method will internally track an opt-in event to your project.
-   *
+   * Resume tracking after optOutTracking(). Also sends a $opt_in event.
    */
   optInTracking() {
     this.oursprivacyImpl.optInTracking(this.token);
   }
 
   /**
-   * Use this method to opt-out a user from tracking. Events and people updates that haven't been
-   * flushed yet will be deleted. Use flush() before calling this method if you want
-   * to send all the queues to OursPrivacy before.
-   *
-   * This method will also remove any user-related information from the device.
+   * Stop all tracking immediately. Queued events that have not been flushed
+   * are discarded. Call flush() first to preserve them.
    */
   optOutTracking() {
     this.oursprivacyImpl.optOutTracking(this.token);
   }
 
   /**
-   * Associate all future calls to track() with the user identified by
-   * the given distinct id.
+   * Link this anonymous visitor to a known user identity.
+   * Call this after login. Sends a $identify event with the provided ID and
+   * user properties.
    *
-   * @param {string} distinctId a string uniquely identifying this user.
-   * @param {object} userProperties Optional user properties to set on identify.
-   * @returns {Promise} A promise that resolves when the identify is successful.
-   *
+   * @param {string} id The user's known identifier (e.g. email or external ID).
+   * @param {object} userProperties Optional properties to attach to this identity.
+   * @returns {Promise}
    */
-  identify(distinctId, userProperties) {
+  identify(id, userProperties) {
     return new Promise((resolve, reject) => {
-      if (!StringHelper.isValid(distinctId)) {
-        StringHelper.raiseError(PARAMS.DISTINCT_ID);
-        reject(new Error("Invalid distinctId"));
+      if (!StringHelper.isValid(id)) {
+        StringHelper.raiseError(PARAMS.ID);
+        reject(new Error("Invalid id"));
       }
       this.oursprivacyImpl
-        .identify(this.token, distinctId, userProperties)
+        .identify(this.token, id, userProperties)
         .then(() => {
           resolve();
         })
@@ -226,9 +161,8 @@ export class OursPrivacy {
   /**
    * Track an event.
    *
-   * @param {string} eventName The name of the event to send
-   * @param {object} properties A Map containing the key value pairs of the properties to include in this event.
-   *                   Pass null if no extra properties exist.
+   * @param {string} eventName The name of the event.
+   * @param {object} properties Optional key/value pairs to include with this event.
    */
   track(eventName, properties) {
     if (!StringHelper.isValid(eventName)) {
@@ -241,85 +175,61 @@ export class OursPrivacy {
   }
 
   /**
-   * Generates a new random visitor id for this instance.
-   * Useful for clearing data when a user logs out.
+   * Clear stored identity and all default properties. Generates a new visitor ID.
+   * Call this when a visitor logs out.
    */
   reset() {
-    if (this._isNative) {
-      this._visitorId = null;
-      this._isManuallySetId = false;
-      this._defaultUserCustomProperties = {};
-      this._defaultUserConsentProperties = {};
-    }
     this.oursprivacyImpl.reset(this.token);
   }
 
   /**
-   * Returns the stable device UUID (visitor id) for this install. No prefix.
-   * On the native path this value is cached during init(); call init() before reading it.
+   * Returns the stable visitor UUID for this install. Synchronous.
+   * This is the value sent as visitor_id on every event.
    *
-   * @return {string|null} The visitor id
+   * @return {string|null}
    */
   getVisitorId() {
-    if (this._isNative) {
-      return this._visitorId;
-    }
     return this.oursprivacyImpl.getVisitorId(this.token);
   }
 
   /**
-   * Update properties merged into eventProperties on every track() call.
-   * On native, delegates to registerSuperProperties() on the native bridge.
+   * Merge properties into eventProperties on every subsequent track() call.
    *
-   * @param {object} properties Key/value pairs to merge into default event properties.
+   * @param {object} properties Key/value pairs to merge.
    */
   updateDefaultEventProperties(properties) {
     if (!ObjectHelper.isValidOrUndefined(properties)) {
       ObjectHelper.raiseError(PARAMS.PROPERTIES);
     }
-    if (this._isNative) {
-      this.oursprivacyImpl.registerSuperProperties(this.token, properties || {});
-    } else {
-      this.oursprivacyImpl.updateDefaultEventProperties(this.token, properties || {});
-    }
+    this.oursprivacyImpl.updateDefaultEventProperties(this.token, properties || {});
   }
 
   /**
-   * Update properties sent with every event in userProperties.custom_properties.
-   * On native, stored JS-side only (native bridge has no userProperties concept).
+   * Merge properties into userProperties.custom_properties on every event.
    *
-   * @param {object} properties Key/value pairs to merge into default user custom properties.
+   * @param {object} properties Key/value pairs to merge.
    */
   updateDefaultUserCustomProperties(properties) {
     if (!ObjectHelper.isValidOrUndefined(properties)) {
       ObjectHelper.raiseError(PARAMS.PROPERTIES);
     }
-    if (this._isNative) {
-      Object.assign(this._defaultUserCustomProperties, properties || {});
-    } else {
-      this.oursprivacyImpl.updateDefaultUserCustomProperties(this.token, properties || {});
-    }
+    this.oursprivacyImpl.updateDefaultUserCustomProperties(this.token, properties || {});
   }
 
   /**
-   * Update consent properties sent with every event in userProperties.consent.
-   * On native, stored JS-side only (native bridge has no userProperties concept).
+   * Merge consent flags into userProperties.consent on every event.
    *
-   * @param {object} properties Key/value pairs to merge into default user consent properties.
+   * @param {object} properties Key/value pairs to merge.
    */
   updateDefaultUserConsentProperties(properties) {
     if (!ObjectHelper.isValidOrUndefined(properties)) {
       ObjectHelper.raiseError(PARAMS.PROPERTIES);
     }
-    if (this._isNative) {
-      Object.assign(this._defaultUserConsentProperties, properties || {});
-    } else {
-      this.oursprivacyImpl.updateDefaultUserConsentProperties(this.token, properties || {});
-    }
+    this.oursprivacyImpl.updateDefaultUserConsentProperties(this.token, properties || {});
   }
 
   /**
-   * Push all queued OursPrivacy events to OursPrivacy servers.
+   * Flush queued events to the Ours Privacy ingest endpoint immediately.
    */
   flush() {
     this.oursprivacyImpl.flush(this.token);
@@ -327,46 +237,28 @@ export class OursPrivacy {
 }
 
 class StringHelper {
-  /**
-      Check whether the parameter is not a blank string.
-     */
   static isValid(str) {
     return typeof str === "string" && !/^\s*$/.test(str);
   }
 
-  /**
-      Check whether the parameter is undefined or not a blank string.
-     */
   static isValidOrUndefined(str) {
     return str === undefined || StringHelper.isValid(str);
   }
 
-  /**
-      Raise a string validation error.
-     */
   static raiseError(paramName) {
     throw new Error(`${paramName}${ERROR_MESSAGE.INVALID_STRING}`);
   }
 }
 
 class ObjectHelper {
-  /**
-      Check whether the parameter is an object.
-     */
   static isValid(obj) {
     return typeof obj === "object";
   }
 
-  /**
-      Check whether the parameter is undefined or an object.
-     */
   static isValidOrUndefined(obj) {
     return obj === undefined || ObjectHelper.isValid(obj);
   }
 
-  /**
-      Raise an object validation error.
-     */
   static raiseError(paramName) {
     throw new Error(`${paramName}${ERROR_MESSAGE.INVALID_OBJECT}`);
   }

--- a/index.js
+++ b/index.js
@@ -83,8 +83,8 @@ export class OursPrivacy {
   }
 
   /**
-   * Control whether OursPrivacy flushes queued events when the app enters the
-   * background on iOS. Enabled by default.
+   * Compatibility API retained from the earlier native-backed SDK surface.
+   * In the current JavaScript runtime this is a safe no-op.
    *
    * @param {boolean} flushOnBackground
    */

--- a/index.js
+++ b/index.js
@@ -1,34 +1,19 @@
 "use strict";
 
 import {Platform, NativeModules} from "react-native";
-import packageJson from "./package.json";
 const {OursPrivacyReactNative} = NativeModules;
 import OursPrivacyMain from "./javascript/oursprivacy-main"
-
-const DevicePlatform = {
-  Unknown: "Unknown",
-  Android: "android",
-  iOS: "ios",
-};
 
 const ERROR_MESSAGE = {
   INVALID_OBJECT: " is not a valid json object",
   INVALID_STRING: " is not a valid string",
-  REQUIRED_DOUBLE: " is not a valid number",
 };
 
 const PARAMS = {
   TOKEN: "token",
   DISTINCT_ID: "distinctId",
-  ALIAS: "alias",
   EVENT_NAME: "eventName",
-  GROUP_KEY: "groupKey",
   PROPERTIES: "properties",
-  PROPERTY_NAME: "propertyName",
-  PROP: "prop",
-  NAME: "name",
-  CHARGE: "charge",
-  PROPERTY_VALUE: "property value",
 };
 
 const DEFAULT_OPT_OUT = false;
@@ -63,58 +48,31 @@ export class OursPrivacy {
    * Initializes OursPrivacy
    *
    * @param {boolean} optOutTrackingDefault Optional Whether or not OursPrivacy can start tracking by default. See optOutTracking()
-   * @param {object} superProperties  Optional A Map containing the key value pairs of the super properties to register
-   * @param {string} serverURL Optional Set the base URL used for OursPrivacy API requests. See setServerURL()
+   * @param {object} options Optional Options object. Supports:
+   *   - serverURL: string
+   *   - user_id: string
+   *   - default_event_properties: object
+   *   - default_user_custom_properties: object
+   *   - default_user_consent_properties: object
    *
    */
   async init(
     optOutTrackingDefault = DEFAULT_OPT_OUT,
-    superProperties = {},
-    serverURL = "https://api.oursprivacy.com/api/v1"
+    options = {}
   ) {
+    const serverURL = (options && options.serverURL) || "https://cdn.oursprivacy.com";
     await this.oursprivacyImpl.initialize(
       this.token,
       this.trackAutomaticEvents,
       optOutTrackingDefault,
-      {...Helper.getMetaData(), ...superProperties},
+      options,
       serverURL
     );
   }
 
   /**
-   * @deprecated since version 1.3.0. To initialize OursPrivacy, please use the instance method `init` instead. See the example below:
-   *
-   * <pre><code>
-   * const trackAutomaticEvents = true;
-   * const oursprivacy = new OursPrivacy('your project token', trackAutomaticEvents);
-   * oursprivacy.init();
-   * </code></pre>
-   *
-   * Initializes OursPrivacy and return an instance of OursPrivacy the given project token.
-   *
-   * @param {string} token your project token.
-   * @param {boolean} trackAutomaticEvents Whether or not to automatically track common mobile events
-   * @param {boolean} Optional Whether or not OursPrivacy can start tracking by default. See optOutTracking()
-   *
-   */
-  static async init(
-    token,
-    trackAutomaticEvents,
-    optOutTrackingDefault = DEFAULT_OPT_OUT
-  ) {
-    await OursPrivacyReactNative.initialize(
-      token,
-      trackAutomaticEvents,
-      optOutTrackingDefault,
-      Helper.getMetaData(),
-      "https://api.oursprivacy.com/api/v1"
-    );
-    return new OursPrivacy(token, trackAutomaticEvents);
-  }
-
-  /**
    * Set the base URL used for OursPrivacy API requests.
-   * Useful if you need to proxy OursPrivacy requests. Defaults to https://api.oursprivacy.com.
+   * Useful if you need to proxy OursPrivacy requests. Defaults to https://cdn.oursprivacy.com.
    * To route data to OursPrivacy's EU servers, set to https://api-eu.oursprivacy.com
    *
    * @param {string} serverURL the base URL used for OursPrivacy API requests
@@ -215,20 +173,9 @@ export class OursPrivacy {
    * Associate all future calls to track() with the user identified by
    * the given distinct id.
    *
-   * <p>Calls to track() made before corresponding calls to identify
-   * will use an anonymous locally generated distinct id, which means it is best to call identify
-   * early to ensure that your OursPrivacy funnels and retention analytics can continue to track the
-   * user throughout their lifetime. We recommend calling identify when the user authenticates.
-   *
-   * <p>Once identify is called, the local distinct id persists across restarts of
-   * your application.
-   *
-   * @param {string} distinctId a string uniquely identifying this user. Events sent to
-   *     OursPrivacy using the same disinct_id will be considered associated with the
-   *     same visitor/customer for retention and funnel reporting, so be sure that the given
-   *     value is globally unique for each individual user you intend to track.
+   * @param {string} distinctId a string uniquely identifying this user.
+   * @param {object} userProperties Optional user properties to set on identify.
    * @returns {Promise} A promise that resolves when the identify is successful.
-   *     It does not return any value.
    *
    */
   identify(distinctId, userProperties) {
@@ -249,35 +196,7 @@ export class OursPrivacy {
   }
 
   /**
-   * @deprecated The alias method creates an alias which OursPrivacy will use to remap one id to another.
-   * Multiple aliases can point to the same identifier.
-   *
-   *  `mixpane.alias("New ID", mixpane.distinctId)`
-   *  `mixpane.alias("Newer ID", mixpane.distinctId)`
-   *
-   * <p>This call does not identify the user after. You must still call identify()
-   *  if you wish the new alias to be used for Events and People.
-   *
-   * @param {string} alias A unique identifier that you want to use as an identifier for this user.
-   * @param {string} distinctId the current distinct_id that alias will be mapped to.
-   */
-  alias(alias, distinctId) {
-    if (!StringHelper.isValid(alias)) {
-      StringHelper.raiseError(PARAMS.ALIAS);
-    }
-    if (!StringHelper.isValid(distinctId)) {
-      StringHelper.raiseError(PARAMS.DISTINCT_ID);
-    }
-    this.oursprivacyImpl.alias(this.token, alias, distinctId);
-  }
-
-  /**
    * Track an event.
-   *
-   * <p>Every call to track eventually results in a data point sent to OursPrivacy. These data points
-   * are what are measured, counted, and broken down to create your OursPrivacy reports. Events
-   * have a string name, and an optional set of name/value pairs that describe the properties of
-   * that event.
    *
    * @param {string} eventName The name of the event to send
    * @param {object} properties A Map containing the key value pairs of the properties to include in this event.
@@ -290,197 +209,67 @@ export class OursPrivacy {
     if (!ObjectHelper.isValidOrUndefined(properties)) {
       ObjectHelper.raiseError(PARAMS.PROPERTIES);
     }
-    this.oursprivacyImpl.track(this.token, eventName, {
-      ...Helper.getMetaData(),
-      ...properties,
-    });
+    this.oursprivacyImpl.track(this.token, eventName, properties);
   }
 
   /**
-   * Register properties that will be sent with every subsequent call to track().
-   *
-   * <p>SuperProperties are a collection of properties that will be sent with every event to OursPrivacy,
-   * and persist beyond the lifetime of your application.
-   *
-   * <p>Setting a superProperty with registerSuperProperties will store a new superProperty,
-   * possibly overwriting any existing superProperty with the same name (to set a
-   * superProperty only if it is currently unset, use registerSuperPropertiesOnce())
-   *
-   * <p>SuperProperties will persist even if your application is taken completely out of memory.
-   * to remove a superProperty, call unregisterSuperProperty() or clearSuperProperties()
-   *
-   * @param {object} properties A Map containing super properties to register
+   * Generates a new random visitor id for this instance.
+   * Useful for clearing data when a user logs out.
    */
-  registerSuperProperties(properties) {
-    if (!ObjectHelper.isValidOrUndefined(properties)) {
-      ObjectHelper.raiseError(PARAMS.PROPERTIES);
-    }
-    this.oursprivacyImpl.registerSuperProperties(this.token, properties || {});
-  }
-
-  /**
-   * Register super properties for events, only if no other super property with the
-   * same names has already been registered.
-   *
-   * <p>Calling registerSuperPropertiesOnce will never overwrite existing properties.
-   *
-   * @param {object} properties A Map containing the super properties to register.
-   */
-  registerSuperPropertiesOnce(properties) {
-    if (!ObjectHelper.isValidOrUndefined(properties)) {
-      ObjectHelper.raiseError(PARAMS.PROPERTIES);
-    }
-    this.oursprivacyImpl.registerSuperPropertiesOnce(this.token, properties || {});
-  }
-
-  /**
-   * Remove a single superProperty, so that it will not be sent with future calls to track().
-   *
-   * <p>If there is a superProperty registered with the given name, it will be permanently
-   * removed from the existing superProperties.
-   * To clear all superProperties, use clearSuperProperties()
-   *
-   * @param {string} propertyName name of the property to unregister
-   */
-  unregisterSuperProperty(propertyName) {
-    if (!StringHelper.isValid(propertyName)) {
-      StringHelper.raiseError(PARAMS.PROPERTY_NAME);
-    }
-    this.oursprivacyImpl.unregisterSuperProperty(this.token, propertyName);
-  }
-
-  /**
-   * Returns a json object of the user's current super properties
-   *
-   *<p>SuperProperties are a collection of properties that will be sent with every event to OursPrivacy,
-   * and persist beyond the lifetime of your application.
-   *
-   * @return {Promise<object>} Super properties for this OursPrivacy instance.
-   */
-  getSuperProperties() {
-    return this.oursprivacyImpl.getSuperProperties(this.token);
-  }
-
-  /**
-   * Erase all currently registered superProperties.
-   *
-   * <p>Future tracking calls to OursPrivacy will not contain the specific
-   * superProperties registered before the clearSuperProperties method was called.
-   *
-   * <p>To remove a single superProperty, use unregisterSuperProperty()
-   */
-  clearSuperProperties() {
-    this.oursprivacyImpl.clearSuperProperties(this.token);
-  }
-
-  /**
-   * Begin timing of an event. Calling timeEvent("Thing") will not send an event, but
-   * when you eventually call track("Thing"), your tracked event will be sent with a "$duration"
-   * property, representing the number of seconds between your calls.
-   *
-   * @param {string} eventName the name of the event to track with timing.
-   */
-  timeEvent(eventName) {
-    if (!StringHelper.isValid(eventName)) {
-      StringHelper.raiseError(PARAMS.EVENT_NAME);
-    }
-    this.oursprivacyImpl.timeEvent(this.token, eventName);
-  }
-
-  /**
-   * Retrieves the time elapsed for the named event since timeEvent() was called.
-   *
-   * @param {string} eventName the name of the event to be tracked that was previously called with timeEvent()
-   *
-   * @return {Promise<number>} Time elapsed since timeEvent(String) was called for the given eventName.
-   */
-  eventElapsedTime(eventName) {
-    if (!StringHelper.isValid(eventName)) {
-      StringHelper.raiseError(PARAMS.EVENT_NAME);
-    }
-    return this.oursprivacyImpl.eventElapsedTime(this.token, eventName);
-  }
-
-  /**
-      Clear super properties and generates a new random distinctId for this instance.
-      Useful for clearing data when a user logs out.
-     */
   reset() {
     this.oursprivacyImpl.reset(this.token);
   }
 
   /**
-   * Returns the current distinct id of the user.
-   * This is either the id automatically generated by the library or the id that has been passed by a call to identify().
+   * Returns the visitor id (stable device UUID, no prefix).
    *
-   * example of usage:
-   * <pre>
-   * <code>
-   * const distinctId = await oursprivacy.getDistinctId();
-   * </code>
-   * </pre>
-   *
-   * @return {Promise<string>} A Promise to the distinct id associated with OursPrivacy event and People Analytics
-   *
+   * @return {string|null} The visitor id
    */
-  getDistinctId() {
-    return this.oursprivacyImpl.getDistinctId(this.token);
+  getVisitorId() {
+    return this.oursprivacyImpl.getVisitorId(this.token);
   }
 
   /**
-   * Returns the current device id of the device.
-   * This id automatically generated by the library and regenerated when logout or reset is called.
+   * Update properties that will be included in defaultProperties.eventProperties for every event.
    *
-   * example of usage:
-   * <pre>
-   * <code>
-   * const deviceId = await oursprivacy.getDeviceId();
-   * </code>
-   * </pre>
-   *
-   * @return {Promise<string>} A Promise to the device id
-   *
+   * @param {object} properties Key/value pairs to merge into default event properties.
    */
-  getDeviceId() {
-    return this.oursprivacyImpl.getDeviceId(this.token);
+  updateDefaultEventProperties(properties) {
+    if (!ObjectHelper.isValidOrUndefined(properties)) {
+      ObjectHelper.raiseError(PARAMS.PROPERTIES);
+    }
+    this.oursprivacyImpl.updateDefaultEventProperties(this.token, properties || {});
   }
 
   /**
-   * Push all queued OursPrivacy events and People Analytics changes to OursPrivacy servers.
+   * Update user custom properties sent with every event in userProperties.custom_properties.
    *
-   * <p>Events and People messages are pushed gradually throughout
-   * the lifetime of your application. This means that to ensure that all messages
-   * are sent to OursPrivacy when your application is shut down, you will
-   * need to call flush() to let the OursPrivacy library know it should
-   * send all remaining messages to the server.
+   * @param {object} properties Key/value pairs to merge into default user custom properties.
+   */
+  updateDefaultUserCustomProperties(properties) {
+    if (!ObjectHelper.isValidOrUndefined(properties)) {
+      ObjectHelper.raiseError(PARAMS.PROPERTIES);
+    }
+    this.oursprivacyImpl.updateDefaultUserCustomProperties(this.token, properties || {});
+  }
+
+  /**
+   * Update user consent properties sent with every event in userProperties.consent.
+   *
+   * @param {object} properties Key/value pairs to merge into default user consent properties.
+   */
+  updateDefaultUserConsentProperties(properties) {
+    if (!ObjectHelper.isValidOrUndefined(properties)) {
+      ObjectHelper.raiseError(PARAMS.PROPERTIES);
+    }
+    this.oursprivacyImpl.updateDefaultUserConsentProperties(this.token, properties || {});
+  }
+
+  /**
+   * Push all queued OursPrivacy events to OursPrivacy servers.
    */
   flush() {
     this.oursprivacyImpl.flush(this.token);
-  }
-}
-
-class Helper {
-  /**
-      Get the library data from package.json file.
-     */
-  static getMetaData() {
-    let metadata = JSON.parse(JSON.stringify(packageJson.metadata));
-    metadata["$lib_version"] = packageJson.version;
-    return metadata;
-  }
-
-  /**
-      Get current device platform.
-     */
-  static getDevicePlatform() {
-    switch (Platform.OS) {
-      case "android":
-        return DevicePlatform.Android;
-      case "ios":
-        return DevicePlatform.iOS;
-      default:
-        return DevicePlatform.Unknown;
-    }
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -33,7 +33,13 @@ export class OursPrivacy {
     this.trackAutomaticEvents = trackAutomaticEvents;
 
     if (useNative && OursPrivacyReactNative) {
+      this._isNative = true;
       this.oursprivacyImpl = OursPrivacyReactNative;
+      // JS-side state for methods the native bridge doesn't export
+      this._visitorId = null;
+      this._isManuallySetId = false;
+      this._defaultUserCustomProperties = {};
+      this._defaultUserConsentProperties = {};
       return;
     } else if (useNative) {
       console.warn(
@@ -41,6 +47,7 @@ export class OursPrivacy {
       );
     }
 
+    this._isNative = false;
     this.oursprivacyImpl = new OursPrivacyMain(token, trackAutomaticEvents, storage);
   }
 
@@ -61,13 +68,49 @@ export class OursPrivacy {
     options = {}
   ) {
     const serverURL = (options && options.serverURL) || "https://cdn.oursprivacy.com";
-    await this.oursprivacyImpl.initialize(
-      this.token,
-      this.trackAutomaticEvents,
-      optOutTrackingDefault,
-      options,
-      serverURL
-    );
+    if (this._isNative) {
+      // Native bridge initialize() expects a flat super-properties map as the 4th
+      // argument. Passing our options object directly would send keys like
+      // default_event_properties as literal super-properties and silently ignore
+      // user_id. Pass an empty map and handle each option explicitly below.
+      await this.oursprivacyImpl.initialize(
+        this.token,
+        this.trackAutomaticEvents,
+        optOutTrackingDefault,
+        {},
+        serverURL
+      );
+      if (options) {
+        if (options.default_event_properties) {
+          await this.oursprivacyImpl.registerSuperProperties(
+            this.token,
+            options.default_event_properties
+          );
+        }
+        if (options.user_id) {
+          this._isManuallySetId = true;
+          this._visitorId = options.user_id;
+        }
+        if (options.default_user_custom_properties) {
+          Object.assign(this._defaultUserCustomProperties, options.default_user_custom_properties);
+        }
+        if (options.default_user_consent_properties) {
+          Object.assign(this._defaultUserConsentProperties, options.default_user_consent_properties);
+        }
+      }
+      // Cache the native device ID so getVisitorId() can return synchronously
+      if (!this._visitorId) {
+        this._visitorId = await this.oursprivacyImpl.getDeviceId(this.token);
+      }
+    } else {
+      await this.oursprivacyImpl.initialize(
+        this.token,
+        this.trackAutomaticEvents,
+        optOutTrackingDefault,
+        options,
+        serverURL
+      );
+    }
   }
 
   /**
@@ -202,20 +245,31 @@ export class OursPrivacy {
    * Useful for clearing data when a user logs out.
    */
   reset() {
+    if (this._isNative) {
+      this._visitorId = null;
+      this._isManuallySetId = false;
+      this._defaultUserCustomProperties = {};
+      this._defaultUserConsentProperties = {};
+    }
     this.oursprivacyImpl.reset(this.token);
   }
 
   /**
-   * Returns the visitor id (stable device UUID, no prefix).
+   * Returns the stable device UUID (visitor id) for this install. No prefix.
+   * On the native path this value is cached during init(); call init() before reading it.
    *
    * @return {string|null} The visitor id
    */
   getVisitorId() {
+    if (this._isNative) {
+      return this._visitorId;
+    }
     return this.oursprivacyImpl.getVisitorId(this.token);
   }
 
   /**
-   * Update properties that will be included in defaultProperties.eventProperties for every event.
+   * Update properties merged into eventProperties on every track() call.
+   * On native, delegates to registerSuperProperties() on the native bridge.
    *
    * @param {object} properties Key/value pairs to merge into default event properties.
    */
@@ -223,11 +277,16 @@ export class OursPrivacy {
     if (!ObjectHelper.isValidOrUndefined(properties)) {
       ObjectHelper.raiseError(PARAMS.PROPERTIES);
     }
-    this.oursprivacyImpl.updateDefaultEventProperties(this.token, properties || {});
+    if (this._isNative) {
+      this.oursprivacyImpl.registerSuperProperties(this.token, properties || {});
+    } else {
+      this.oursprivacyImpl.updateDefaultEventProperties(this.token, properties || {});
+    }
   }
 
   /**
-   * Update user custom properties sent with every event in userProperties.custom_properties.
+   * Update properties sent with every event in userProperties.custom_properties.
+   * On native, stored JS-side only (native bridge has no userProperties concept).
    *
    * @param {object} properties Key/value pairs to merge into default user custom properties.
    */
@@ -235,11 +294,16 @@ export class OursPrivacy {
     if (!ObjectHelper.isValidOrUndefined(properties)) {
       ObjectHelper.raiseError(PARAMS.PROPERTIES);
     }
-    this.oursprivacyImpl.updateDefaultUserCustomProperties(this.token, properties || {});
+    if (this._isNative) {
+      Object.assign(this._defaultUserCustomProperties, properties || {});
+    } else {
+      this.oursprivacyImpl.updateDefaultUserCustomProperties(this.token, properties || {});
+    }
   }
 
   /**
-   * Update user consent properties sent with every event in userProperties.consent.
+   * Update consent properties sent with every event in userProperties.consent.
+   * On native, stored JS-side only (native bridge has no userProperties concept).
    *
    * @param {object} properties Key/value pairs to merge into default user consent properties.
    */
@@ -247,7 +311,11 @@ export class OursPrivacy {
     if (!ObjectHelper.isValidOrUndefined(properties)) {
       ObjectHelper.raiseError(PARAMS.PROPERTIES);
     }
-    this.oursprivacyImpl.updateDefaultUserConsentProperties(this.token, properties || {});
+    if (this._isNative) {
+      Object.assign(this._defaultUserConsentProperties, properties || {});
+    } else {
+      this.oursprivacyImpl.updateDefaultUserConsentProperties(this.token, properties || {});
+    }
   }
 
   /**

--- a/ios/AutomaticProperties.swift
+++ b/ios/AutomaticProperties.swift
@@ -158,7 +158,7 @@ class AutomaticProperties {
     }
 
     class func libVersion() -> String {
-        return "1.1.0"
+        return "1.2.0"
     }
 
 }

--- a/ios/Info.plist
+++ b/ios/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.0</string>
+	<string>1.2.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/ios/OursPrivacy-swift.podspec
+++ b/ios/OursPrivacy-swift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'OursPrivacy-swift'
-  s.version = '1.1.0'
+  s.version = '1.2.0'
   s.module_name = 'OursPrivacy'
   s.license = 'Apache License, Version 2.0'
   s.summary = 'Ours Privacy tracking library for iOS (Swift)'

--- a/javascript/oursprivacy-config.js
+++ b/javascript/oursprivacy-config.js
@@ -99,4 +99,12 @@ export class OursPrivacyConfig {
       defaultFlushInterval
     );
   }
+
+  setIsManuallySetId(token, isManuallySetId) {
+    this._config[token] = {...this._config[token], isManuallySetId};
+  }
+
+  getIsManuallySetId(token) {
+    return (this._config[token] && this._config[token].isManuallySetId) || false;
+  }
 }

--- a/javascript/oursprivacy-config.js
+++ b/javascript/oursprivacy-config.js
@@ -53,24 +53,6 @@ export class OursPrivacyConfig {
     );
   }
 
-  setUseIpAddressForGeolocation(token, useIpAddressForGeolocation) {
-    this._config[token] = {
-      ...this._config[token],
-      useIpAddressForGeolocation,
-    };
-    OursPrivacyLogger.log(
-      token,
-      `Set useIpAddressForGeolocation: ${useIpAddressForGeolocation}`
-    );
-  }
-
-  getUseIpAddressForGeolocation(token) {
-    return (
-      (this._config[token] && this._config[token].useIpAddressForGeolocation) ||
-      true
-    );
-  }
-
   setFlushBatchSize(token, batchSize) {
     this._config[token] = {
       ...this._config[token],

--- a/javascript/oursprivacy-constants.js
+++ b/javascript/oursprivacy-constants.js
@@ -1,7 +1,5 @@
 export const OursPrivacyType = {
-  EVENTS: "/track/",
-  USER: "/engage/",
-  GROUPS: "/groups/",
+  EVENTS: "/ingest",
 };
 
 export const getQueueKey = (token, type) => `OURSPRIVACY_${token}_${type}_QUEUE`;
@@ -17,6 +15,6 @@ export const getTimeEventsKey = (token) => `OURSPRIVACY_${token}_TIME_EVENTS`;
 export const getAppHasOpenedBeforeKey = (token) =>
   `OURSPRIVACY_${token}_APP_HAS_OPENED_BEFORE`;
 
-export const defaultServerURL = `https://api.oursprivacy.com`;
+export const defaultServerURL = `https://cdn.oursprivacy.com`;
 export const defaultBatchSize = 50;
 export const defaultFlushInterval = 10 * 1000; // 10s

--- a/javascript/oursprivacy-core.js
+++ b/javascript/oursprivacy-core.js
@@ -1,6 +1,5 @@
 import {OursPrivacyQueueManager} from "./oursprivacy-queue";
 import {OursPrivacyNetwork} from "./oursprivacy-network";
-import {SessionMetadata} from "./oursprivacy-utils";
 import {OursPrivacyType} from "./oursprivacy-constants";
 import {OursPrivacyConfig} from "./oursprivacy-config";
 import {OursPrivacyPersistent} from "./oursprivacy-persistent";
@@ -38,8 +37,6 @@ export const OursPrivacyCore = (storage) => {
     processQueueInterval = setInterval(async () => {
       clearInterval(processQueueInterval);
       await processQueue(token, OursPrivacyType.EVENTS);
-      await processQueue(token, OursPrivacyType.USER);
-      await processQueue(token, OursPrivacyType.GROUPS);
 
       isProcessingQueue = false;
       startProcessingQueue(token);
@@ -71,19 +68,10 @@ export const OursPrivacyCore = (storage) => {
       );
       return;
     }
-    const sessionMetadata = new SessionMetadata();
-    await OursPrivacyQueueManager.enqueue(token, type, {
-      ...sessionMetadata.toDict(type),
-      ...data,
-    });
+    await OursPrivacyQueueManager.enqueue(token, type, data);
     OursPrivacyLogger.log(
       token,
-      `The oursprivacy payload is added to the OursPrivacy queue. Payload: '${JSON.stringify(
-        {
-          ...sessionMetadata.toDict(type),
-          ...data,
-        }
-      )}' Type: '${type}' `
+      `Event added to queue. Payload: '${JSON.stringify(data)}'`
     );
   };
 
@@ -96,8 +84,6 @@ export const OursPrivacyCore = (storage) => {
       return;
     }
     await processQueue(token, OursPrivacyType.EVENTS);
-    await processQueue(token, OursPrivacyType.USER);
-    await processQueue(token, OursPrivacyType.GROUPS);
   };
 
   const processQueue = async (token, type) => {
@@ -118,8 +104,7 @@ export const OursPrivacyCore = (storage) => {
             data: batch,
             endpoint: type,
             serverURL: config.getServerURL(token),
-            useIPAddressForGeoLocation:
-              config.getUseIpAddressForGeolocation(token),
+            isManuallySetId: config.getIsManuallySetId(token),
           });
           await OursPrivacyQueueManager.spliceQueue(token, type, 0, batch.length);
           // Process the next batch if there are more events in the queue

--- a/javascript/oursprivacy-main.js
+++ b/javascript/oursprivacy-main.js
@@ -3,6 +3,7 @@ import {OursPrivacyCore} from "./oursprivacy-core";
 import {OursPrivacyType} from "./oursprivacy-constants";
 import {OursPrivacyConfig} from "./oursprivacy-config";
 import {OursPrivacyPersistent} from "./oursprivacy-persistent";
+import {OursPrivacyQueueManager} from "./oursprivacy-queue";
 import {OursPrivacyLogger} from "./oursprivacy-logger";
 import packageJson from "../package.json";
 import uuid from "uuid";
@@ -30,35 +31,15 @@ export default class OursPrivacyMain {
     OursPrivacyLogger.log(token, `Initializing OursPrivacy`);
 
     await this.oursprivacyPersistent.initializationCompletePromise(token);
-    if (optOutTrackingDefault) {
-      await this.optOutTracking(token);
-      return;
-    } else {
-      await this._setOptedOutTrackingFlag(token, false);
-    }
 
     this.setServerURL(token, serverURL);
+    await this._applyInitializationOptions(token, options);
 
-    if (options && typeof options === "object") {
-      if (options.default_event_properties) {
-        this.updateDefaultEventProperties(token, options.default_event_properties);
-      }
-      if (options.default_user_custom_properties) {
-        this.updateDefaultUserCustomProperties(token, options.default_user_custom_properties);
-      }
-      if (options.default_user_consent_properties) {
-        this.updateDefaultUserConsentProperties(token, options.default_user_consent_properties);
-      }
-      if (options.visitor_id) {
-        this.config.setIsManuallySetId(token, true);
-        // Override the stable visitor UUID with the caller-supplied ID so that
-        // visitor_id on all subsequent events reflects the provided value.
-        this.oursprivacyPersistent.updateDeviceId(token, options.visitor_id);
-        this.oursprivacyPersistent.updateDistinctId(token, options.visitor_id);
-        await this.oursprivacyPersistent.persistDeviceId(token);
-        await this.oursprivacyPersistent.persistDistinctId(token);
-      }
+    if (optOutTrackingDefault) {
+      await this._setOptedOutTrackingFlag(token, true);
+      return;
     }
+    await this._setOptedOutTrackingFlag(token, false);
   }
 
   getDefaultProperties() {
@@ -144,12 +125,20 @@ export default class OursPrivacyMain {
     this.config.setFlushBatchSize(token, flushBatchSize);
   }
 
+  setFlushOnBackground(token, flushOnBackground) {
+    OursPrivacyLogger.log(
+      token,
+      `setFlushOnBackground(${String(flushOnBackground)}) is ignored in JavaScript mode.`
+    );
+  }
+
   flush(token) {
     this.core.flush(token);
   }
 
   async optOutTracking(token) {
     await this._setOptedOutTrackingFlag(token, true);
+    await OursPrivacyQueueManager.clearQueue(token, OursPrivacyType.EVENTS);
     OursPrivacyLogger.log(token, "User has opted out of tracking");
     await this.oursprivacyPersistent.reset(token);
   }
@@ -166,7 +155,7 @@ export default class OursPrivacyMain {
   }
 
   hasOptedOutTracking(token) {
-    return this.oursprivacyPersistent.getOptOut(token);
+    return this.oursprivacyPersistent.getOptedOut(token);
   }
 
   async identify(token, newDistinctId, userProperties) {
@@ -242,5 +231,30 @@ export default class OursPrivacyMain {
       ...(this._defaultUserConsentProperties[token] || {}),
       ...properties,
     };
+  }
+
+  async _applyInitializationOptions(token, options) {
+    if (!options || typeof options !== "object") {
+      return;
+    }
+
+    if (options.default_event_properties) {
+      this.updateDefaultEventProperties(token, options.default_event_properties);
+    }
+    if (options.default_user_custom_properties) {
+      this.updateDefaultUserCustomProperties(token, options.default_user_custom_properties);
+    }
+    if (options.default_user_consent_properties) {
+      this.updateDefaultUserConsentProperties(token, options.default_user_consent_properties);
+    }
+    if (options.visitor_id) {
+      this.config.setIsManuallySetId(token, true);
+      // Override the stable visitor UUID with the caller-supplied ID so that
+      // visitor_id on all subsequent events reflects the provided value.
+      this.oursprivacyPersistent.updateDeviceId(token, options.visitor_id);
+      this.oursprivacyPersistent.updateDistinctId(token, options.visitor_id);
+      await this.oursprivacyPersistent.persistDeviceId(token);
+      await this.oursprivacyPersistent.persistDistinctId(token);
+    }
   }
 }

--- a/javascript/oursprivacy-main.js
+++ b/javascript/oursprivacy-main.js
@@ -51,6 +51,12 @@ export default class OursPrivacyMain {
       }
       if (options.user_id) {
         this.config.setIsManuallySetId(token, true);
+        // Override the stable device UUID with the caller-supplied ID so that
+        // visitor_id on all subsequent events reflects the provided value.
+        this.oursprivacyPersistent.updateDeviceId(token, options.user_id);
+        this.oursprivacyPersistent.updateDistinctId(token, options.user_id);
+        await this.oursprivacyPersistent.persistDeviceId(token);
+        await this.oursprivacyPersistent.persistDistinctId(token);
       }
     }
   }
@@ -97,6 +103,9 @@ export default class OursPrivacyMain {
       properties
     );
 
+    // visitor_id: stable UUID for this device/install (persisted in AsyncStorage).
+    // distinct_id: a new UUID generated per-event — it is a unique ID for this
+    //   specific event occurrence, NOT a user ID. Do not confuse with visitor_id.
     const visitorId = this.oursprivacyPersistent.getDeviceId(token);
     const distinctId = uuid.v4();
 

--- a/javascript/oursprivacy-main.js
+++ b/javascript/oursprivacy-main.js
@@ -131,13 +131,6 @@ export default class OursPrivacyMain {
     this.config.setServerURL(token, serverURL);
   }
 
-  setUseIpAddressForGeolocation(token, useIpAddressForGeolocation) {
-    this.config.setUseIpAddressForGeolocation(
-      token,
-      useIpAddressForGeolocation
-    );
-  }
-
   setFlushBatchSize(token, flushBatchSize) {
     this.config.setFlushBatchSize(token, flushBatchSize);
   }

--- a/javascript/oursprivacy-main.js
+++ b/javascript/oursprivacy-main.js
@@ -49,12 +49,12 @@ export default class OursPrivacyMain {
       if (options.default_user_consent_properties) {
         this.updateDefaultUserConsentProperties(token, options.default_user_consent_properties);
       }
-      if (options.user_id) {
+      if (options.visitor_id) {
         this.config.setIsManuallySetId(token, true);
-        // Override the stable device UUID with the caller-supplied ID so that
+        // Override the stable visitor UUID with the caller-supplied ID so that
         // visitor_id on all subsequent events reflects the provided value.
-        this.oursprivacyPersistent.updateDeviceId(token, options.user_id);
-        this.oursprivacyPersistent.updateDistinctId(token, options.user_id);
+        this.oursprivacyPersistent.updateDeviceId(token, options.visitor_id);
+        this.oursprivacyPersistent.updateDistinctId(token, options.visitor_id);
         await this.oursprivacyPersistent.persistDeviceId(token);
         await this.oursprivacyPersistent.persistDistinctId(token);
       }

--- a/javascript/oursprivacy-main.js
+++ b/javascript/oursprivacy-main.js
@@ -5,6 +5,7 @@ import {OursPrivacyConfig} from "./oursprivacy-config";
 import {OursPrivacyPersistent} from "./oursprivacy-persistent";
 import {OursPrivacyLogger} from "./oursprivacy-logger";
 import packageJson from "../package.json";
+import uuid from "uuid";
 
 export default class OursPrivacyMain {
   constructor(token, trackAutomaticEvents, storage) {
@@ -14,14 +15,17 @@ export default class OursPrivacyMain {
     this.core.initialize(token);
     this.core.startProcessingQueue(token);
     this.oursprivacyPersistent = OursPrivacyPersistent.getInstance();
+    this._defaultEventProperties = {};
+    this._defaultUserCustomProperties = {};
+    this._defaultUserConsentProperties = {};
   }
 
   async initialize(
     token,
     trackAutomaticEvents = false,
     optOutTrackingDefault = false,
-    superProperties = null,
-    serverURL = "https://api.oursprivacy.com/api/v1"
+    options = {},
+    serverURL = "https://cdn.oursprivacy.com"
   ) {
     OursPrivacyLogger.log(token, `Initializing OursPrivacy`);
 
@@ -34,40 +38,48 @@ export default class OursPrivacyMain {
     }
 
     this.setServerURL(token, serverURL);
-    await this.registerSuperProperties(token, {
-      ...superProperties,
-    });
+
+    if (options && typeof options === "object") {
+      if (options.default_event_properties) {
+        this.updateDefaultEventProperties(token, options.default_event_properties);
+      }
+      if (options.default_user_custom_properties) {
+        this.updateDefaultUserCustomProperties(token, options.default_user_custom_properties);
+      }
+      if (options.default_user_consent_properties) {
+        this.updateDefaultUserConsentProperties(token, options.default_user_consent_properties);
+      }
+      if (options.user_id) {
+        this.config.setIsManuallySetId(token, true);
+      }
+    }
   }
 
-  getMetaData() {
+  getDefaultProperties() {
     const {OS, Version, constants} = Platform;
-    const {Brand, Manufacturer, Model} = constants || {};
+    const {Model, Manufacturer, Brand} = constants || {};
 
-    let metadata = {
-      $os: OS,
-      $os_version: Version,
-      ...JSON.parse(JSON.stringify(packageJson.metadata)),
-      $lib_version: packageJson.version,
+    const props = {
+      device_type: "mobile",
+      os_name: OS === "ios" ? "iOS" : OS === "android" ? "Android" : OS,
+      os_version: String(Version),
+      version: packageJson.version,
     };
     if (OS === "ios") {
-      metadata = {
-        ...metadata,
-        $manufacturer: "Apple",
-      };
+      props.device_vendor = "Apple";
+      if (Model) props.device_model = Model;
     } else if (OS === "android") {
-      metadata = {
-        ...metadata,
-        $android_brand: Brand,
-        $android_manufacturer: Manufacturer,
-        $android_model: Model,
-      };
+      props.device_vendor = Manufacturer || Brand || undefined;
+      if (Model) props.device_model = Model;
     }
-
-    return metadata;
+    return props;
   }
 
   async reset(token) {
     await this.oursprivacyPersistent.reset(token);
+    this._defaultEventProperties[token] = {};
+    this._defaultUserCustomProperties[token] = {};
+    this._defaultUserConsentProperties[token] = {};
   }
 
   async track(token, eventName, properties) {
@@ -84,36 +96,30 @@ export default class OursPrivacyMain {
       `Track '${eventName}' with properties`,
       properties
     );
-    const superProperties = this.oursprivacyPersistent.getSuperProperties(token);
-    const identityProps = {
-      distinct_id: this.oursprivacyPersistent.getDistinctId(token),
-      $device_id: this.oursprivacyPersistent.getDeviceId(token),
-      $user_id: this.oursprivacyPersistent.getUserId(token),
-    };
-    const eventElapsedTime = await this.eventElapsedTime(token, eventName);
-    const eventProperties = Object.freeze({
-      token,
-      time: Date.now(),
-      ...this.getMetaData(),
-      ...superProperties,
+
+    const visitorId = this.oursprivacyPersistent.getDeviceId(token);
+    const distinctId = uuid.v4();
+
+    const rawEventProps = {
+      ...(this._defaultEventProperties[token] || {}),
       ...properties,
-      ...identityProps,
-      ...(eventElapsedTime !== null && {
-        $duration: eventElapsedTime,
-      }),
-    });
+    };
 
-    const eventData = Object.freeze({
+    const customProps = this._defaultUserCustomProperties[token] || {};
+    const consentProps = this._defaultUserConsentProperties[token] || {};
+    const userProps = {};
+    if (Object.keys(customProps).length > 0) userProps.custom_properties = {...customProps};
+    if (Object.keys(consentProps).length > 0) userProps.consent = {...consentProps};
+
+    const eventData = {
       event: eventName,
-      properties: eventProperties,
-    });
+      visitor_id: visitorId,
+      distinct_id: distinctId,
+      eventProperties: Object.keys(rawEventProps).length > 0 ? rawEventProps : null,
+      userProperties: Object.keys(userProps).length > 0 ? userProps : null,
+      defaultProperties: this.getDefaultProperties(),
+    };
 
-    if (eventElapsedTime !== null) {
-      let timeEvents = this.oursprivacyPersistent.getTimeEvents(token);
-      delete timeEvents[eventName];
-      this.oursprivacyPersistent.updateTimeEvents(token, timeEvents);
-      await this.oursprivacyPersistent.persistTimeEvents(token);
-    }
     await this.core.addToOursPrivacyQueue(token, OursPrivacyType.EVENTS, eventData);
   }
 
@@ -161,7 +167,7 @@ export default class OursPrivacyMain {
     return this.oursprivacyPersistent.getOptOut(token);
   }
 
-  async identify(token, newDistinctId) {
+  async identify(token, newDistinctId, userProperties) {
     OursPrivacyLogger.log(token, `Identify '${newDistinctId}'`);
     const oldDistinctId = this.oursprivacyPersistent.getDistinctId(token);
     if (oldDistinctId === newDistinctId) {
@@ -173,389 +179,66 @@ export default class OursPrivacyMain {
     }
     this.oursprivacyPersistent.updateDistinctId(token, newDistinctId);
     this.oursprivacyPersistent.updateUserId(token, newDistinctId);
-    const deviceId = this.oursprivacyPersistent.getDeviceId(token);
     await this.oursprivacyPersistent.persistIdentity(token);
-    await this.track(token, "$identify", {
-      distinctId: newDistinctId,
-      $user_id: newDistinctId,
-      $anon_distinct_id: oldDistinctId,
-      $device_id: deviceId,
-    });
-  }
 
-  async alias(token, alias, distinctId) {
-    OursPrivacyLogger.log(token, `Alias '${alias}' to '${distinctId}'`);
-    await this.track(token, "$create_alias", {
-      alias,
+    const visitorId = this.oursprivacyPersistent.getDeviceId(token);
+    const distinctId = uuid.v4();
+
+    const customProps = this._defaultUserCustomProperties[token] || {};
+    const consentProps = this._defaultUserConsentProperties[token] || {};
+
+    const identifyUserProps = {
+      external_id: newDistinctId,
+      ...(userProperties || {}),
+    };
+
+    if (Object.keys(customProps).length > 0) {
+      identifyUserProps.custom_properties = {
+        ...customProps,
+        ...(userProperties && userProperties.custom_properties ? userProperties.custom_properties : {}),
+      };
+    }
+    if (Object.keys(consentProps).length > 0) {
+      identifyUserProps.consent = {
+        ...consentProps,
+        ...(userProperties && userProperties.consent ? userProperties.consent : {}),
+      };
+    }
+
+    const eventData = {
+      event: "$identify",
+      visitor_id: visitorId,
       distinct_id: distinctId,
-    });
-    await this.identify(token, distinctId);
+      eventProperties: null,
+      userProperties: identifyUserProps,
+      defaultProperties: this.getDefaultProperties(),
+    };
+
+    await this.core.addToOursPrivacyQueue(token, OursPrivacyType.EVENTS, eventData);
   }
 
-  async getDeviceId(token) {
-    if (!this.oursprivacyPersistent.getDeviceId(token)) {
-      await this.oursprivacyPersistent.loadIdentity(token);
-    }
-    return this.identity[token].deviceId;
+  getVisitorId(token) {
+    return this.oursprivacyPersistent.getDeviceId(token);
   }
 
-  async getDistinctId(token) {
-    if (!this.oursprivacyPersistent.getDistinctId(token)) {
-      await this.oursprivacyPersistent.loadIdentity(token);
-    }
-    return this.oursprivacyPersistent.getDistinctId(token);
-  }
-
-  async _updateSuperProperties(token, properties) {
-    this.oursprivacyPersistent.updateSuperProperties(token, properties);
-    await this.oursprivacyPersistent.persistSuperProperties(token);
-  }
-
-  async registerSuperProperties(token, properties) {
-    OursPrivacyLogger.log(token, `Register super properties:`, properties);
-    const currentSuperProperties = this.oursprivacyPersistent.getSuperProperties(
-      token
-    );
-    OursPrivacyLogger.log(
-      token,
-      `Current Super Properties:`,
-      currentSuperProperties
-    );
-    const updatedSuperProperties = {
-      ...currentSuperProperties,
+  updateDefaultEventProperties(token, properties) {
+    this._defaultEventProperties[token] = {
+      ...(this._defaultEventProperties[token] || {}),
       ...properties,
     };
-
-    this._updateSuperProperties(token, updatedSuperProperties);
-    OursPrivacyLogger.log(
-      token,
-      `Updated Super Properties:`,
-      updatedSuperProperties
-    );
   }
 
-  async registerSuperPropertiesOnce(token, properties) {
-    OursPrivacyLogger.log(token, `Register super properties once`, properties);
-    const currentSuperProperties = this.oursprivacyPersistent.getSuperProperties(
-      token
-    );
-
-    const updatedSuperProperties = {
+  updateDefaultUserCustomProperties(token, properties) {
+    this._defaultUserCustomProperties[token] = {
+      ...(this._defaultUserCustomProperties[token] || {}),
       ...properties,
-      ...currentSuperProperties,
     };
-
-    this._updateSuperProperties(token, updatedSuperProperties);
-    OursPrivacyLogger.log(
-      token,
-      `Updated Super Properties:`,
-      updatedSuperProperties
-    );
   }
 
-  async unregisterSuperProperty(token, propertyName) {
-    OursPrivacyLogger.log(token, `Unregister super property '${propertyName}'`);
-    let superProperties = this.oursprivacyPersistent.getSuperProperties(token);
-    delete superProperties[propertyName];
-    this._updateSuperProperties(token, superProperties);
-    OursPrivacyLogger.log(token, `Updated Super Properties:`, superProperties);
-  }
-
-  async getSuperProperties(token) {
-    if (!this.oursprivacyPersistent.getSuperProperties(token)) {
-      await this.oursprivacyPersistent.loadSuperProperties(token);
-    }
-    return this.oursprivacyPersistent.getSuperProperties(token);
-  }
-
-  async clearSuperProperties(token) {
-    OursPrivacyLogger.log(token, `Clear super properties`);
-    this._updateSuperProperties(token, {});
-    OursPrivacyLogger.log(token, `Updated Super Properties:`, {});
-  }
-
-  async timeEvent(token, eventName) {
-    const currentTime = Math.round(Date.now() / 1000);
-    OursPrivacyLogger.log(
-      token,
-      `Add time event '${eventName}' at`,
-      new Date(currentTime * 1000).toLocaleString()
-    );
-    this.oursprivacyPersistent.updateTimeEvents(token, {
-      ...this.oursprivacyPersistent.getTimeEvents(token),
-      [eventName]: currentTime,
-    });
-    await this.oursprivacyPersistent.persistTimeEvents(token);
-  }
-
-  async eventElapsedTime(token, eventName) {
-    if (!this.oursprivacyPersistent.getTimeEvents(token)) {
-      await this.oursprivacyPersistent.loadTimeEvents(token);
-    }
-    const timeEvents = this.oursprivacyPersistent.getTimeEvents(token);
-    const startTime = timeEvents ? timeEvents[eventName] : undefined;
-
-    if (startTime) {
-      const duration = Math.round(Date.now() / 1000) - startTime;
-      return duration;
-    }
-    return null;
-  }
-
-  async sendProfileDataToOursPrivacy(token, action) {
-    const profileData = {
-      $token: token,
-      $time: Date.now(),
-      ...action,
-      $distinct_id: this.oursprivacyPersistent.getDistinctId(token),
-      $device_id: this.oursprivacyPersistent.getDeviceId(token),
-      $user_id: this.oursprivacyPersistent.getUserId(token),
+  updateDefaultUserConsentProperties(token, properties) {
+    this._defaultUserConsentProperties[token] = {
+      ...(this._defaultUserConsentProperties[token] || {}),
+      ...properties,
     };
-    await this.core.addToOursPrivacyQueue(token, OursPrivacyType.USER, profileData);
-  }
-
-  async sendGroupDataToOursPrivacy({token, groupKey, groupID, action}) {
-    const profileData = {
-      $token: token,
-      $time: Date.now(),
-      $group_key: groupKey,
-      $group_id: groupID,
-      ...action,
-    };
-    await this.core.addToOursPrivacyQueue(token, OursPrivacyType.GROUPS, profileData);
-  }
-
-  async set(token, properties) {
-    OursPrivacyLogger.log(token, `Set properties: `, properties);
-    await this.sendProfileDataToOursPrivacy(token, {$set: properties});
-  }
-
-  async setOnce(token, properties) {
-    OursPrivacyLogger.log(token, `Set once properties: `, properties);
-    await this.sendProfileDataToOursPrivacy(token, {$set_once: properties});
-  }
-
-  async increment(token, properties) {
-    OursPrivacyLogger.log(token, `Increment properties: `, properties);
-    await this.sendProfileDataToOursPrivacy(token, {$add: properties});
-  }
-
-  async append(token, nameOrProperties, value) {
-    if (typeof nameOrProperties === "string" && value !== undefined) {
-      OursPrivacyLogger.log(token, `Append properties: `, {
-        [nameOrProperties]: value,
-      });
-      await this.sendProfileDataToOursPrivacy(token, {
-        $append: {[nameOrProperties]: value},
-      });
-    } else if (typeof nameOrProperties === "object") {
-      OursPrivacyLogger.log(token, `Append properties: `, nameOrProperties);
-      await this.sendProfileDataToOursPrivacy(token, {
-        $append: nameOrProperties,
-      });
-    }
-  }
-
-  async union(token, nameOrProperties, value) {
-    if (typeof nameOrProperties === "string" && value !== undefined) {
-      OursPrivacyLogger.log(token, `Union properties: `, {
-        [nameOrProperties]: value,
-      });
-      await this.sendProfileDataToOursPrivacy(token, {
-        $union: {[nameOrProperties]: value},
-      });
-    } else if (typeof nameOrProperties === "object") {
-      OursPrivacyLogger.log(token, `Union properties: `, nameOrProperties);
-      await this.sendProfileDataToOursPrivacy(token, {$union: nameOrProperties});
-    }
-  }
-
-  async remove(token, nameOrProperties, value) {
-    if (typeof nameOrProperties === "string" && value !== undefined) {
-      OursPrivacyLogger.log(token, `Remove properties: `, {
-        [nameOrProperties]: value,
-      });
-      await this.sendProfileDataToOursPrivacy(token, {
-        $remove: {[nameOrProperties]: value},
-      });
-    } else if (typeof nameOrProperties === "object") {
-      OursPrivacyLogger.log(token, `Remove properties: `, nameOrProperties);
-      await this.sendProfileDataToOursPrivacy(token, {
-        $remove: nameOrProperties,
-      });
-    }
-  }
-
-  async trackCharge(token, charge, properties) {
-    OursPrivacyLogger.log(token, `Track charge: `, charge, properties);
-    await this.append(token, {
-      $transactions: {$amount: charge, $time: Date.now(), ...properties},
-    });
-  }
-
-  async clearCharges(token) {
-    OursPrivacyLogger.log(token, `Clear charges`);
-    await this.set(token, {
-      $transactions: [],
-    });
-  }
-
-  async unset(token, property) {
-    OursPrivacyLogger.log(token, `Unset property: `, property);
-    await this.sendProfileDataToOursPrivacy(token, {$unset: [property]});
-  }
-
-  async deleteUser(token) {
-    OursPrivacyLogger.log(token, `Delete user`);
-    await this.sendProfileDataToOursPrivacy(token, {$delete: "null"});
-  }
-
-  async groupSetProperties(token, groupKey, groupID, properties) {
-    OursPrivacyLogger.log(
-      token,
-      `Group set properties: `,
-      groupKey,
-      groupID,
-      properties
-    );
-    await this.sendGroupDataToOursPrivacy({
-      token,
-      groupKey,
-      groupID,
-      action: {
-        $set: properties,
-      },
-    });
-  }
-
-  async groupSetPropertyOnce(token, groupKey, groupID, properties) {
-    OursPrivacyLogger.log(
-      token,
-      `Group set once properties: `,
-      groupKey,
-      groupID,
-      properties
-    );
-    await this.sendGroupDataToOursPrivacy({
-      token,
-      groupKey,
-      groupID,
-      action: {
-        $set_once: properties,
-      },
-    });
-  }
-
-  async groupUnsetProperty(token, groupKey, groupID, prop) {
-    OursPrivacyLogger.log(
-      token,
-      `Group unset property: `,
-      groupKey,
-      groupID,
-      prop
-    );
-    await this.sendGroupDataToOursPrivacy({
-      token,
-      groupKey,
-      groupID,
-      action: {
-        $unset: [prop],
-      },
-    });
-  }
-
-  async groupRemovePropertyValue(token, groupKey, groupID, name, value) {
-    OursPrivacyLogger.log(
-      token,
-      `Group remove property value: `,
-      groupKey,
-      groupID,
-      name,
-      value
-    );
-    await this.sendGroupDataToOursPrivacy({
-      token,
-      groupKey,
-      groupID,
-      action: {
-        $remove: {[name]: value},
-      },
-    });
-  }
-
-  async groupUnionProperty(token, groupKey, groupID, name, value) {
-    OursPrivacyLogger.log(
-      token,
-      `Group union property: `,
-      groupKey,
-      groupID,
-      name,
-      value
-    );
-    await this.sendGroupDataToOursPrivacy({
-      token,
-      groupKey,
-      groupID,
-      action: {
-        $union: {[name]: value},
-      },
-    });
-  }
-
-  async trackWithGroups(token, eventName, properties, groups) {
-    OursPrivacyLogger.log(
-      token,
-      `Track with groups: `,
-      eventName,
-      properties,
-      groups
-    );
-    await this.track(token, eventName, {...properties, ...groups});
-  }
-
-  async setGroup(token, groupKey, groupID) {
-    OursPrivacyLogger.log(token, `Set group: `, groupKey, groupID);
-    const properties = {[groupKey]: [groupID]};
-    await this.registerSuperProperties(token, properties);
-    await this.set(token, properties);
-  }
-
-  async addGroup(token, groupKey, groupID) {
-    OursPrivacyLogger.log(token, `Add group: `, groupKey, groupID);
-    const superProperties = this.oursprivacyPersistent.getSuperProperties(token);
-    const groupArray = superProperties[groupKey] || [];
-    if (!groupArray.includes(groupID)) {
-      this.registerSuperProperties(token, {
-        [groupKey]: [...groupArray, groupID],
-      });
-    }
-    await this.union(token, {[groupKey]: [groupID]});
-  }
-
-  async removeGroup(token, groupKey, groupID) {
-    OursPrivacyLogger.log(token, `Remove group: `, groupKey, groupID);
-    const superProperties = this.oursprivacyPersistent.getSuperProperties(token);
-    if (superProperties && superProperties[groupKey]) {
-      const filteredGroup = superProperties[groupKey].filter(
-        (id) => id !== groupID
-      );
-      this.registerSuperProperties(token, {[groupKey]: filteredGroup});
-      if (filteredGroup.length === 0) {
-        this.unregisterSuperProperty(token, groupKey);
-      }
-    }
-    await this.remove(token, {[groupKey]: groupID});
-  }
-
-  async deleteGroup(token, groupKey, groupID) {
-    OursPrivacyLogger.log(token, `Delete group: `, groupKey, groupID);
-    await this.sendGroupDataToOursPrivacy({
-      token,
-      groupKey,
-      groupID,
-      action: {
-        $delete: "null",
-      },
-    });
   }
 }

--- a/javascript/oursprivacy-network.js
+++ b/javascript/oursprivacy-network.js
@@ -13,41 +13,48 @@ export const OursPrivacyNetwork = (() => {
     endpoint,
     data,
     serverURL,
-    useIPAddressForGeoLocation,
+    isManuallySetId = false,
     retryCount = 0,
   }) => {
     retryCount = retryCount || 0;
-    const url = `${serverURL}${endpoint}?ip=${+useIPAddressForGeoLocation}`;
+    const url = `${serverURL}${endpoint}`;
     OursPrivacyLogger.log(token, `Sending request to: ${url}`);
 
     try {
       const response = await fetch(url, {
         method: "POST",
         headers: {
-          "Content-Type": "application/x-www-form-urlencoded",
+          "Content-Type": "application/json",
         },
-        body: `data=${encodeURIComponent(JSON.stringify(data))}`,
+        body: JSON.stringify({
+          token,
+          is_manually_set_id: isManuallySetId,
+          data,
+        }),
       });
 
-      const responseBody = await response.json();
-      if (response.status !== 200) {
+      let responseBody;
+      try {
+        responseBody = await response.json();
+      } catch (_) {
+        responseBody = {};
+      }
+
+      if (!response.ok) {
         throw new OursPrivacyHttpError(
           `HTTP error! status: ${response.status}`,
           response.status
         );
       }
 
-      const message =
-        responseBody === 0
-          ? `${url} api rejected some items`
-          : `OursPrivacy batch sent successfully, endpoint: ${endpoint}, data: ${JSON.stringify(
-              data
-            )}`;
+      OursPrivacyLogger.log(
+        token,
+        `OursPrivacy batch sent successfully, endpoint: ${endpoint}`
+      );
 
-      OursPrivacyLogger.log(token, message);
+      return responseBody;
     } catch (error) {
       if (error.code === 400) {
-        // This indicates that the data was invalid and we should not retry
         throw new OursPrivacyHttpError(
           `HTTP error! status: ${error.code}`,
           error.code
@@ -58,7 +65,7 @@ export const OursPrivacyNetwork = (() => {
         `API request to ${url} has failed with reason: ${error.message}`
       );
       const maxRetries = 5;
-      const backoff = Math.min(2 ** retryCount * 2000, 60000); // Exponential backoff
+      const backoff = Math.min(2 ** retryCount * 2000, 60000);
       if (retryCount < maxRetries) {
         OursPrivacyLogger.log(token, `Retrying in ${backoff / 1000} seconds...`);
         await new Promise((resolve) => setTimeout(resolve, backoff));
@@ -67,7 +74,7 @@ export const OursPrivacyNetwork = (() => {
           endpoint,
           data,
           serverURL,
-          useIPAddressForGeoLocation,
+          isManuallySetId,
           retryCount: retryCount + 1,
         });
       } else {

--- a/javascript/oursprivacy-persistent.js
+++ b/javascript/oursprivacy-persistent.js
@@ -78,8 +78,7 @@ export class OursPrivacyPersistent {
         this._identity[token].distinctId = distinctId;
       });
     if (!this._identity[token].distinctId) {
-      this._identity[token].distinctId =
-        "$device:" + this._identity[token].deviceId;
+      this._identity[token].distinctId = this._identity[token].deviceId;
       await this.storageAdapter.setItem(
         getDistinctIdKey(token),
         this._identity[token].distinctId

--- a/javascript/oursprivacy-queue.js
+++ b/javascript/oursprivacy-queue.js
@@ -55,10 +55,10 @@ export const OursPrivacyQueueManager = (() => {
   };
 
   const clearQueue = async (token, type) => {
-    if (!_queues[token] || !_queues[token][type]) {
-      return;
-    }
-    _queues[token][type] = [];
+    _queues[token] = {
+      ..._queues[token],
+      [type]: [],
+    };
     await updateQueueInStorage(token, type);
   };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oursprivacy/react-native",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Official React Native Tracking Library for OursPrivacy Analytics",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
## Summary

- **Endpoint**: Switch from `api.oursprivacy.com/api/v1/track` → `cdn.oursprivacy.com/ingest` (web-ingest Lambda, client-facing — CloudFront infers IP + user agent)
- **Payload format**: Align with `packages/types/src/event.ts` schema — `{ token, is_manually_set_id, data: [...] }` where each event has `{ event, visitor_id, distinct_id, eventProperties, userProperties, defaultProperties }`
- **Three-tier properties**: `eventProperties` (per-event custom), `userProperties` (custom + consent), `defaultProperties` (auto-collected device/SDK metadata)
- **New API**: `updateDefaultEventProperties()`, `updateDefaultUserCustomProperties()`, `updateDefaultUserConsentProperties()`, `getVisitorId()`, `init(optOut, options)` with `default_event_properties` / `default_user_custom_properties` / `default_user_consent_properties` / `user_id` options
- **Removed Mixpanel legacy**: `alias()`, `registerSuperProperties*()`, `timeEvent()`, `eventElapsedTime()`, `getDistinctId()`, `getDeviceId()`, static `OursPrivacy.init()`
- **Visitor ID**: Removed `$device:` prefix — now returns clean UUID
- **`is_manually_set_id`**: Set to `true` when `user_id` passed in `init()` options
- **Tests**: All 49/49 pass; new tests cover network payload shape, `isManuallySetId` propagation, and three-tier event structure
- **Demo app**: Updated to use current API — exercises all documented methods
- **README + public docs**: Updated to document current API only, no deprecated methods

## Test plan

- [ ] `npm test` — 49/49 pass
- [ ] Run Demo app on iOS simulator: `cd Demo && npx react-native run-ios --simulator="iPhone 16 Pro"`
- [ ] Tap "Track Event" — verify `button_pressed` event fires in console
- [ ] Tap "Identify User" — verify identify event logs
- [ ] Tap "Update Defaults + Track" — verify defaults_updated event logs
- [ ] Tap "Opt Out" / "Opt In" — verify opt-out flag persists, $opt_in event fires on opt-in
- [ ] Tap "Reset" — verify new visitor_id generated
- [ ] Check payload shape in network inspector: `cdn.oursprivacy.com/ingest`, body has `{ token, is_manually_set_id, data: [...] }`