### PR TITLE
refactor: use OIDC npm OUR-4016

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   publish:
@@ -27,8 +28,9 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org
+          package-manager-cache: false
 
       - name: Extract version
         id: version
@@ -64,8 +66,6 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create git tag and GitHub release
         run: |


### PR DESCRIPTION
## Summary

  Enable npm trusted publishing with GitHub Actions OIDC
  and remove reliance on long-lived npm publish tokens.

  ## Changes

  - Adds `id-token: write` permission for the npm publish
  workflow.
  - Publishes with npm trusted publishing instead of
  `NODE_AUTH_TOKEN` / `NPM_TOKEN`.
  - Keeps existing release behavior intact for package
  publishing.
  - Uses a supported Node/npm runtime for OIDC
  publishing.

  ## Why

  npm trusted publishing issues short-lived publish
  credentials through GitHub OIDC. This removes the need
  to store long-lived npm tokens in GitHub secrets and
  reduces the blast radius of token exposure from CI,
  logs, dependency lifecycle scripts, or compromised
  runners.

  ## Verification

  - Confirmed the workflow runs on GitHub-hosted runners.
  - Confirmed the publish workflow filename matches the
  npm Trusted Publisher configuration.
  - Confirmed the publish step no longer receives a long-
  lived npm token.
  - Publish will require the npm package Trusted
  Publisher entry to be configured before merge/release.

  Optional note to include if useful:

  ## Pre-merge checklist

  - [ ] Configure npm Trusted Publisher for this package.
  - [ ] Verify GitHub org/repo/workflow filename match
  npm exactly.
  - [ ] After a successful OIDC publish, revoke the old
  npm automation token.