### PR TITLE
ci: split publish job, add zizmor, pin actions OUR-4084

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,74 @@
+# Supply-chain hardening: Dependabot opens PRs to keep GitHub Actions
+# pinned to current commit SHAs.
+#
+# When Dependabot proposes a bump, the PR will include the action's resolved
+# commit SHA with a trailing version comment (e.g.
+# `uses: actions/checkout@<40-char SHA> # v6.0.2`). Accept those PRs to land
+# SHA pinning across this repo's workflows.
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "fix"
+    # GitHub recommends pinning by SHA for supply-chain safety. Dependabot
+    # honors this when the existing reference is a SHA; for refs that are
+    # still on a major-tag float, the first Dependabot PR will replace the
+    # float with a SHA pin. After that, weekly bumps land as SHA-to-SHA.
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "npm"
+    commit-message:
+      prefix: "fix"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+      prod-minor-patch:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/Demo"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "npm"
+      - "demo"
+    commit-message:
+      prefix: "chore"
+    groups:
+      demo-deps:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,14 +6,23 @@ on:
   pull_request:
     branches: [dev]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
           cache: npm
@@ -25,8 +34,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/pr-title-validation.yml
+++ b/.github/workflows/pr-title-validation.yml
@@ -7,11 +7,18 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   pr-title-check:
+    name: PR Title Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Check PR Title Format
         env:

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -11,22 +11,33 @@ on:
         description: "Version to publish (e.g., 1.1.0)"
         required: true
 
-permissions:
-  contents: write
-  id-token: write
+permissions: {}
+
+concurrency:
+  group: publish-npm
+  cancel-in-progress: false
 
 jobs:
-  publish:
-    name: Publish to npm
+  # Build + test runs without id-token: write and without npm registry creds,
+  # so a malicious dep installed by `npm ci` cannot exfiltrate publish auth.
+  # Tarball is handed to the publish job via artifact.
+  build:
+    name: Build & Test
     runs-on: ubuntu-latest
     if: >
       (github.event_name == 'workflow_dispatch') ||
       (github.event.pull_request.merged == true &&
        startsWith(github.event.pull_request.title, 'release:'))
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
@@ -34,12 +45,15 @@ jobs:
 
       - name: Extract version
         id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="${{ github.event.inputs.version }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="$INPUT_VERSION"
           else
-            TITLE="${{ github.event.pull_request.title }}"
-            VERSION=$(echo "$TITLE" | grep -oP '\d+\.\d+\.\d+')
+            VERSION=$(echo "$PR_TITLE" | grep -oP '\d+\.\d+\.\d+')
           fi
 
           if [ -z "$VERSION" ]; then
@@ -56,7 +70,7 @@ jobs:
           fi
 
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Publishing version: $VERSION"
+          echo "Building version: $VERSION"
 
       - run: npm ci
 
@@ -64,17 +78,57 @@ jobs:
 
       - run: npx tsc --noEmit
 
-      - name: Publish to npm
-        run: npm publish --access public
+      - name: Pack tarball
+        run: npm pack
+
+      - name: Upload tarball artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: npm-package
+          path: oursprivacy-react-native-*.tgz
+          if-no-files-found: error
+          retention-days: 7
+
+  # Publish runs in an isolated job: no `npm ci`, no project deps loaded.
+  # `npm publish <tarball>` does not execute package lifecycle scripts, so
+  # no third-party JS runs in this job's env where OIDC tokens are present.
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: write # push release tag, create GitHub release
+      id-token: write # npm Trusted Publishing via OIDC + npm provenance
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: Download tarball artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: npm-package
+          path: .
+
+      - name: Publish tarball to npm
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: npm publish "oursprivacy-react-native-${VERSION}.tgz" --access public --provenance
 
       - name: Create git tag and GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: v${{ needs.build.outputs.version }}
         run: |
-          VERSION="v${{ steps.version.outputs.version }}"
           git tag "$VERSION"
-          git push origin "$VERSION"
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$VERSION"
 
           gh release create "$VERSION" \
             --title "$VERSION" \
             --generate-notes
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,35 @@
+name: Zizmor
+
+on:
+  push:
+    branches: [dev]
+  pull_request:
+    branches: [dev]
+    paths:
+      - ".github/workflows/**"
+      - ".github/dependabot.yml"
+      - ".github/workflows/zizmor.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  zizmor:
+    name: Zizmor
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.1.0
+        with:
+          enable-cache: true
+
+      - name: Run zizmor
+        run: uvx zizmor --min-severity medium --persona regular .


### PR DESCRIPTION
## Summary

Closes the in-job exfiltration shape from OUR-4083/OUR-4084 (the audit finding in `docs/supply-chain-security.md`). PR #19 migrated `npm publish` to OIDC and removed `NPM_TOKEN`, but `npm ci` + `npm test` still ran in the same job as the publish step. A malicious dep loaded during install could read `ACTIONS_ID_TOKEN_REQUEST_TOKEN`/`_URL` from process env and mint its own publish credential — same pattern as Nx (Aug 2025).

This PR also pulls in the supply-chain hardening items we flagged in the same review.

## Changes

**Split `publish-npm.yml` into two jobs**
- `build` — `permissions: contents: read`. Runs `npm ci`, `npm test`, `npx tsc`, `npm pack`. No `id-token` available, no registry creds in env.
- `publish` — `needs: build`. Downloads the tarball artifact and runs `npm publish <tgz> --access public --provenance`. No `npm ci`, no project deps loaded. `npm publish` of a tarball does not execute package lifecycle scripts, so no third-party JS runs alongside the OIDC token.

**zizmor scanner**
- New `.github/workflows/zizmor.yml` runs `uvx zizmor` on PRs touching `.github/` and on pushes to `dev`. Threshold: `--min-severity medium --persona regular`.

**Action SHA pinning**
- All third-party actions pinned to 40-char commit SHAs with `# vX.Y.Z` trailing comments: `actions/checkout`, `actions/setup-node`, `actions/upload-artifact`, `actions/download-artifact`, `astral-sh/setup-uv`.

**Dependabot**
- New `.github/dependabot.yml`: weekly `github-actions` ecosystem updates (keeps SHA pins current) plus npm groups for root + `Demo/`.

**Other hardening**
- Script injection fixed in `publish-npm.yml`: PR title and `workflow_dispatch` input now flow through env vars instead of being interpolated into bash.
- `permissions: contents: read` added to `ci.yml` (was inheriting the repo default).
- `permissions: {}` at the workflow level on `publish-npm.yml`; per-job scope for `contents: write` (tag/release) and `id-token: write` (OIDC).
- `persist-credentials: false` on all checkouts. Tag push in publish uses `GITHUB_TOKEN` explicitly.
- `npm publish --provenance` flag (pairs with the OIDC change from #19).
- Concurrency cancellation on CI and PR-title PR runs; serialized non-cancelling group on publish.

## Test plan

- [ ] CI passes (test, typecheck, pr-title-check, zizmor)
- [ ] Local zizmor run is clean at `--persona pedantic` (verified)
- [ ] Next `release: X.Y.Z` PR: confirm build job uploads tarball, publish job downloads it, `npm publish` succeeds via OIDC, tag + GitHub release are created, published package contents match the previous release's manifest
- [ ] Manual log inspection on the first release: confirm no `ACTIONS_ID_TOKEN_*` env vars appear in the build job's log (only publish job)

## Rollback

Revert this commit on `dev`. The prior workflow files still work.