### PR TITLE
release: 2.0.0

### DIFF
--- a/Demo/.env.example
+++ b/Demo/.env.example
@@ -1,3 +1,6 @@
 OURSPRIVACY_TOKEN=YOUR_API_TOKEN
 OURSPRIVACY_SERVER_URL=
 E2E_AUTOFIRE=
+# SDK resolution: `npm` (default) uses the package in node_modules; `local`
+# aliases @oursprivacy/react-native to the repo root via Metro for live testing.
+OURSPRIVACY_SDK_SOURCE=npm

--- a/Demo/App.tsx
+++ b/Demo/App.tsx
@@ -54,7 +54,7 @@ function Section({ children, title }: SectionProps): React.JSX.Element {
 }
 
 // Initialize SDK once using instance pattern
-const oursprivacy = new OursPrivacy(OURSPRIVACY_TOKEN, false, false);
+const oursprivacy = new OursPrivacy(OURSPRIVACY_TOKEN, false);
 
 // Test initialURL init option: parse a simulated deep link at init time
 const SIMULATED_COLD_START_URL =

--- a/Demo/README.md
+++ b/Demo/README.md
@@ -16,7 +16,26 @@ The Demo exercises the main SDK flows exposed in `App.tsx`:
 
 The `ios/` and `android/` folders are required. This Demo is a bare React Native app, so those native project shells are how `run-ios` and `run-android` work.
 
-## Install the Packed SDK
+## Pick an SDK Source
+
+The Demo can resolve `@oursprivacy/react-native` two ways. Set `OURSPRIVACY_SDK_SOURCE` in `Demo/.env`:
+
+| Value | Resolves to | When to use |
+|-------|-------------|-------------|
+| `npm` (default) | Whatever is installed in `Demo/node_modules/@oursprivacy/react-native` (e.g. a packed tgz or a published version) | Verifying the published artifact |
+| `local` | The repo root — Metro aliases the package and watches the SDK source | Iterating on SDK changes; edits to `index.js`, `javascript/*` reload immediately |
+
+No `package.json` edit is needed to switch — Metro reads the env var on startup. Restart Metro after toggling.
+
+### When using `local`
+
+```sh
+# From Demo/
+echo "OURSPRIVACY_SDK_SOURCE=local" >> .env
+npm install   # still needed once for react-native / async-storage
+```
+
+### When using `npm` with a freshly packed tgz
 
 From the repo root:
 
@@ -38,6 +57,7 @@ Set values in `Demo/.env`:
 ```sh
 OURSPRIVACY_TOKEN=demo-token
 OURSPRIVACY_SERVER_URL=http://127.0.0.1:4010
+OURSPRIVACY_SDK_SOURCE=npm   # or `local`
 ```
 
 Use these server URLs:

--- a/Demo/metro.config.js
+++ b/Demo/metro.config.js
@@ -1,11 +1,50 @@
+const path = require('path');
+const fs = require('fs');
 const {getDefaultConfig, mergeConfig} = require('@react-native/metro-config');
 
-/**
- * Metro configuration
- * https://reactnative.dev/docs/metro
- *
- * @type {import('@react-native/metro-config').MetroConfig}
- */
-const config = {};
+// Minimal .env reader so this works on a fresh clone without adding a runtime dep.
+// We can't use react-native-dotenv here — that's a babel plugin and runs after
+// metro.config.js has already loaded.
+function readEnvFile(filePath) {
+  if (!fs.existsSync(filePath)) return {};
+  const out = {};
+  for (const rawLine of fs.readFileSync(filePath, 'utf8').split('\n')) {
+    const match = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)\s*$/.exec(rawLine);
+    if (!match) continue;
+    out[match[1]] = match[2].replace(/^['"]|['"]$/g, '');
+  }
+  return out;
+}
 
-module.exports = mergeConfig(getDefaultConfig(__dirname), config);
+const envFromFile = readEnvFile(path.resolve(__dirname, '.env'));
+const sdkSource =
+  process.env.OURSPRIVACY_SDK_SOURCE || envFromFile.OURSPRIVACY_SDK_SOURCE || 'npm';
+const useLocalSdk = sdkSource === 'local';
+const sdkRoot = path.resolve(__dirname, '..');
+
+console.log(
+  `[metro] @oursprivacy/react-native source: ${useLocalSdk ? `local (${sdkRoot})` : 'npm'}`,
+);
+
+const localOverrides = useLocalSdk
+  ? {
+      watchFolders: [sdkRoot],
+      resolver: {
+        // When the SDK source (outside Demo/) imports react / react-native /
+        // async-storage, force resolution through Demo/node_modules so we don't
+        // bundle two copies. The Proxy returns Demo/node_modules/<name> for any
+        // module not explicitly aliased.
+        extraNodeModules: new Proxy(
+          {'@oursprivacy/react-native': sdkRoot},
+          {
+            get(target, name) {
+              if (name in target) return target[name];
+              return path.resolve(__dirname, 'node_modules', name);
+            },
+          },
+        ),
+      },
+    }
+  : {};
+
+module.exports = mergeConfig(getDefaultConfig(__dirname), localOverrides);

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ export default function App() {
 
 ### Initialization
 
-#### `new OursPrivacy(token, trackAutomaticEvents, useNative?, storage?)`
+#### `new OursPrivacy(token, trackAutomaticEvents, storage?)`
 
 Creates an OursPrivacy instance. You must call `.init()` before tracking.
 
@@ -129,7 +129,6 @@ Creates an OursPrivacy instance. You must call `.init()` before tracking.
 |-----------|------|----------|-------------|
 | `token` | `string` | Yes | Your project token |
 | `trackAutomaticEvents` | `boolean` | Yes | Whether to track automatic events |
-| `useNative` | `boolean` | No | Accepted but ignored |
 | `storage` | `OursPrivacyAsyncStorage` | No | Custom AsyncStorage adapter |
 
 **Returns:** `OursPrivacy` instance (call `.init()` to complete setup)
@@ -597,6 +596,22 @@ The SDK sends a JSON body to `POST /ingest` on the configured `serverURL`. Under
 | `defaultProperties` | Automatically collected device/SDK metadata |
 
 ---
+
+## Migration
+
+### From 1.x to 2.x
+
+The `useNative` constructor argument was removed in 2.0.0. The SDK has always run pure JavaScript, so the argument was a no-op — but its position shifted, so any call that passed `storage` positionally needs to drop the third argument.
+
+```js
+// 1.x
+const op = new OursPrivacy('TOKEN', false, false, customStorage);
+
+// 2.x
+const op = new OursPrivacy('TOKEN', false, customStorage);
+```
+
+If you never passed anything beyond `token` and `trackAutomaticEvents`, no change is required.
 
 ## Migration from Mixpanel
 

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,4 +1,5 @@
 import {OursPrivacy} from "oursprivacy-react-native";
+import OursPrivacyMain from "oursprivacy-react-native/javascript/oursprivacy-main";
 
 // OursPrivacy always uses JS mode. Mock OursPrivacyMain so index.test.js
 // verifies the wrapper delegates correctly without executing JS SDK internals.
@@ -24,6 +25,10 @@ jest.mock("oursprivacy-react-native/javascript/oursprivacy-main", () => ({
     })),
 }));
 
+beforeEach(() => {
+  OursPrivacyMain.mockClear();
+});
+
 test(`it initializes with correct defaults`, async () => {
   const op = new OursPrivacy("token", false);
   await op.init();
@@ -34,6 +39,26 @@ test(`it initializes with correct defaults`, async () => {
     {},
     "https://cdn.oursprivacy.com"
   );
+});
+
+test(`constructor passes storage at position 3 of OursPrivacyMain`, () => {
+  const storage = {getItem: jest.fn(), setItem: jest.fn(), removeItem: jest.fn()};
+  new OursPrivacy("token", false, storage);
+  expect(OursPrivacyMain).toHaveBeenCalledWith("token", false, storage);
+});
+
+test(`constructor omits storage when not provided`, () => {
+  new OursPrivacy("token", false);
+  expect(OursPrivacyMain).toHaveBeenCalledWith("token", false, undefined);
+});
+
+test(`constructor throws when token is missing or blank`, () => {
+  expect(() => new OursPrivacy("", false)).toThrow();
+  expect(() => new OursPrivacy("   ", false)).toThrow();
+});
+
+test(`constructor throws when trackAutomaticEvents is undefined`, () => {
+  expect(() => new OursPrivacy("token")).toThrow(/trackAutomaticEvents/);
 });
 
 test(`it passes optOut and options to initialize`, async () => {

--- a/index.d.ts
+++ b/index.d.ts
@@ -27,12 +27,9 @@ export type OursPrivacyUserProperties = {
 };
 
 export class OursPrivacy {
-  constructor(token: string, trackAutoMaticEvents: boolean);
-  constructor(token: string, trackAutoMaticEvents: boolean, useNative: true);
   constructor(
     token: string,
     trackAutomaticEvents: boolean,
-    useNative: false,
     storage?: OursPrivacyAsyncStorage
   );
   init(

--- a/index.js
+++ b/index.js
@@ -19,13 +19,9 @@ const DEFAULT_OPT_OUT = false;
 
 /**
  * The primary class for integrating OursPrivacy with your app.
- *
- * Always uses the JavaScript implementation regardless of the useNative argument.
- * The native iOS/Android modules (forked from Mixpanel) generate a payload format
- * that does not match the Ours Privacy ingest schema, so they are not used.
  */
 export class OursPrivacy {
-  constructor(token, trackAutomaticEvents, useNative = true, storage) {
+  constructor(token, trackAutomaticEvents, storage) {
     if (!StringHelper.isValid(token)) {
       StringHelper.raiseError(PARAMS.TOKEN);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oursprivacy/react-native",
-  "version": "1.4.2",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oursprivacy/react-native",
-      "version": "1.4.2",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oursprivacy/react-native",
-  "version": "1.4.2",
+  "version": "2.0.0",
   "description": "Official React Native Tracking Library for OursPrivacy Analytics",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
## Summary

- Wave 0 cleanup release. Drops the unused `useNative` constructor argument from `OursPrivacy`. The argument has been ignored since the SDK went pure-JS, but its position in the signature kept dead code in `index.js`, `index.d.ts`, the README, and the Demo.
- Adds a Metro-driven `OURSPRIVACY_SDK_SOURCE` toggle to the Demo so the app can resolve `@oursprivacy/react-native` from the repo root (`local`) or from the installed package (`npm`) without editing `Demo/package.json` or juggling tgz filenames on every release.
- Bumps `package.json` to `2.0.0`.

## Breaking change

Constructor signature changes:

```js
// 1.x
new OursPrivacy(token, trackAutomaticEvents, useNative?, storage?)

// 2.x
new OursPrivacy(token, trackAutomaticEvents, storage?)
```

Callers that passed `storage` positionally need to drop the third argument. Callers using only `(token, trackAutomaticEvents)` are unaffected. README has a migration note.

## Test plan

- [x] `npm test` — 104/104 pass (4 new tests cover the new constructor shape)
- [x] `npm run typecheck` — clean
- [ ] Demo: set `OURSPRIVACY_SDK_SOURCE=local` in `Demo/.env`, run `npm run ios`, confirm Metro logs `source: local (...)` and edits to `index.js` hot-reload
- [ ] Demo: set `OURSPRIVACY_SDK_SOURCE=npm` (or unset), confirm Metro logs `source: npm` and the installed package is used
- [ ] After merge: publish workflow tags `2.0.0` and pushes to npm