### PR TITLE
fix: install OIDC-compatible npm in publish job

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -116,6 +116,11 @@ jobs:
           name: npm-package
           path: .
 
+      # Node's bundled npm is older than the CLI version required by npm's
+      # OIDC Trusted Publishing endpoint. Pin a known-good version.
+      - name: Install OIDC-compatible npm
+        run: npm install -g npm@11.6.2
+
       - name: Publish tarball to npm
         env:
           VERSION: ${{ needs.build.outputs.version }}


### PR DESCRIPTION
## Summary

- Node 24's bundled npm CLI is too old for npm registry's OIDC Trusted Publishing endpoint — `npm publish` succeeded in signing a provenance statement, but the subsequent `PUT /@oursprivacy/react-native` returned `400 OIDC publish authorize: Invalid token`.
- Pin `npm@11.6.2` in the publish job before running `npm publish`, matching the working setup used in `ingest-sdk-nodejs`.

## Test plan

- [x] Merge to `dev`
- [x] Re-run publish via `workflow_dispatch` with `version=2.0.0`
- [x] Confirm `@oursprivacy/react-native@2.0.0` appears on npm