### PR TITLE
debug: print OIDC claims to diagnose npm TP rejection

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -122,18 +122,20 @@ jobs:
         run: npm install -g npm@11.6.2
 
       - name: Debug — decode OIDC claims for npm audience
-        env:
-          ACTIONS_ID_TOKEN_REQUEST_TOKEN: ${{ env.ACTIONS_ID_TOKEN_REQUEST_TOKEN }}
-          ACTIONS_ID_TOKEN_REQUEST_URL: ${{ env.ACTIONS_ID_TOKEN_REQUEST_URL }}
         run: |
           set -e
           TOKEN=$(curl -sS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
             "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=npm:registry.npmjs.org" | jq -r .value)
+          # Mask raw token + raw payload so neither leaks into public logs.
+          echo "::add-mask::$TOKEN"
           PAYLOAD=$(echo "$TOKEN" | cut -d. -f2)
+          echo "::add-mask::$PAYLOAD"
           # base64url -> base64
           PAD=$(( (4 - ${#PAYLOAD} % 4) % 4 ))
           PADDED="$PAYLOAD$(printf '=%.0s' $(seq 1 $PAD))"
-          echo "$PADDED" | tr '_-' '/+' | base64 -d 2>/dev/null | jq .
+          DECODED=$(echo "$PADDED" | tr '_-' '/+' | base64 -d 2>/dev/null)
+          # Only print claims relevant to npm Trusted Publisher matching.
+          echo "$DECODED" | jq '{iss, aud, repository, repository_owner, workflow, workflow_ref, job_workflow_ref, ref, ref_type, event_name, environment}'
 
       - name: Publish tarball to npm
         env:

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -121,6 +121,20 @@ jobs:
       - name: Install OIDC-compatible npm
         run: npm install -g npm@11.6.2
 
+      - name: Debug — decode OIDC claims for npm audience
+        env:
+          ACTIONS_ID_TOKEN_REQUEST_TOKEN: ${{ env.ACTIONS_ID_TOKEN_REQUEST_TOKEN }}
+          ACTIONS_ID_TOKEN_REQUEST_URL: ${{ env.ACTIONS_ID_TOKEN_REQUEST_URL }}
+        run: |
+          set -e
+          TOKEN=$(curl -sS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=npm:registry.npmjs.org" | jq -r .value)
+          PAYLOAD=$(echo "$TOKEN" | cut -d. -f2)
+          # base64url -> base64
+          PAD=$(( (4 - ${#PAYLOAD} % 4) % 4 ))
+          PADDED="$PAYLOAD$(printf '=%.0s' $(seq 1 $PAD))"
+          echo "$PADDED" | tr '_-' '/+' | base64 -d 2>/dev/null | jq .
+
       - name: Publish tarball to npm
         env:
           VERSION: ${{ needs.build.outputs.version }}

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -177,3 +177,18 @@ Copyright 2022 OursPrivacy, Inc.
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
+
+----------------------------------------------------------------------
+
+ATTRIBUTION
+
+This product includes software originally developed by Mixpanel, Inc.
+(https://mixpanel.com/), licensed under the Apache License, Version 2.0.
+
+Portions of this software are derived from the Mixpanel React Native SDK:
+    Copyright Mixpanel, Inc.
+    Licensed under the Apache License, Version 2.0.
+
+Modifications and additional software:
+    Copyright 2022 OursPrivacy, Inc.
+    Licensed under the Apache License, Version 2.0.


### PR DESCRIPTION
## Summary

- Temporary diagnostic step: decode the OIDC token's payload (for the `npm:registry.npmjs.org` audience) and print only the claims used by npm Trusted Publisher matching — `repository`, `workflow_ref`, `ref`, `event_name`, `environment`, etc.
- Raw token and raw base64 payload are masked via `::add-mask::` so they cannot leak into public logs.
- To be reverted once we identify the claim mismatch.

## Test plan

- [ ] Merge to `dev`
- [ ] Run publish via `workflow_dispatch` with `version=2.0.0`
- [ ] Inspect the printed claims; compare to npm TP config
- [ ] Open follow-up PR with the actual fix + revert this debug step