### PR TITLE
fix(ci): revert publish to NPM_TOKEN auth

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -91,14 +91,13 @@ jobs:
 
   # Publish runs in an isolated job: no `npm ci`, no project deps loaded.
   # `npm publish <tarball>` does not execute package lifecycle scripts, so
-  # no third-party JS runs in this job's env where OIDC tokens are present.
+  # no third-party JS runs in this job's env where NPM_TOKEN is present.
   publish:
     name: Publish to npm
     runs-on: ubuntu-latest
     needs: build
     permissions:
       contents: write # push release tag, create GitHub release
-      id-token: write # npm Trusted Publishing via OIDC + npm provenance
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -116,28 +115,11 @@ jobs:
           name: npm-package
           path: .
 
-      # Node's bundled npm is older than the CLI version required by npm's
-      # OIDC Trusted Publishing endpoint. Pin a known-good version.
-      - name: Install OIDC-compatible npm
-        run: npm install -g npm@11.6.2
-
-      - name: Debug — decode OIDC claims for npm audience
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v8.0.0
-        with:
-          script: |
-            const token = await core.getIDToken('npm:registry.npmjs.org');
-            core.setSecret(token);
-            const payload = token.split('.')[1];
-            core.setSecret(payload);
-            const decoded = JSON.parse(Buffer.from(payload, 'base64url').toString());
-            const interesting = (({ iss, aud, repository, repository_owner, repository_id, workflow, workflow_ref, job_workflow_ref, ref, ref_type, event_name, environment, sub }) =>
-              ({ iss, aud, repository, repository_owner, repository_id, workflow, workflow_ref, job_workflow_ref, ref, ref_type, event_name, environment, sub }))(decoded);
-            console.log(JSON.stringify(interesting, null, 2));
-
       - name: Publish tarball to npm
         env:
           VERSION: ${{ needs.build.outputs.version }}
-        run: npm publish "oursprivacy-react-native-${VERSION}.tgz" --access public --provenance
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish "oursprivacy-react-native-${VERSION}.tgz" --access public
 
       - name: Create git tag and GitHub release
         env:


### PR DESCRIPTION
## Summary

- npm OIDC Trusted Publishing with `--provenance` is not supported when the source repository is private — npm rejects with `OIDC publish authorize: Invalid token`. Repo is currently private, so revert to `NPM_TOKEN` secret-based auth and drop `--provenance`.
- Removes the OIDC-only steps: `id-token: write` permission, npm@11.6.2 pin, debug claims decoder.

## Test plan

- [ ] Merge to `dev`
- [ ] Dispatch publish workflow with `version=2.0.0`
- [ ] Confirm `@oursprivacy/react-native@2.0.0` lands on npm