### PR TITLE
feat: flush queued events when app moves to background

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,11 +372,11 @@ op.setLoggingEnabled(true);
 
 #### `op.setFlushOnBackground(flushOnBackground)`
 
-This method has no effect in the current SDK.
+Toggle automatic flushing when the app moves to the background. Enabled by default.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `flushOnBackground` | `boolean` | Yes | Ignored |
+| `flushOnBackground` | `boolean` | Yes | `true` to flush on background (default), `false` to disable. |
 
 **Returns:** `void`
 

--- a/__tests__/integration.test.js
+++ b/__tests__/integration.test.js
@@ -18,6 +18,18 @@ const waitForFetchCalls = async (count, attempts = 20) => {
   expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(count);
 };
 
+// Captures the AppState 'change' handler the SDK registers so the test
+// can simulate the app moving to background.
+const installAppStateCapture = () => {
+  const RN = require("react-native");
+  const captured = {handler: null, removed: false};
+  RN.AppState.addEventListener = jest.fn((event, handler) => {
+    if (event === "change") captured.handler = handler;
+    return {remove: jest.fn(() => { captured.removed = true; })};
+  });
+  return captured;
+};
+
 describe("OursPrivacy integration flows", () => {
   beforeEach(() => {
     jest.resetModules();
@@ -304,5 +316,58 @@ describe("OursPrivacy integration flows", () => {
     const body2 = JSON.parse(fetchMock.mock.calls[0][1].body);
     const s5 = body2.data.find((e) => e.event === "no_user_props_anywhere");
     expect(s5.userProperties).toBeNull();
+  });
+
+  it("flushes queued events when the app moves to background", async () => {
+    fetchMock.mockResponse(JSON.stringify({success: true}), {status: 200});
+
+    const appState = installAppStateCapture();
+
+    const {OursPrivacy} = require("oursprivacy-react-native");
+    const op = new OursPrivacy();
+
+    await op.init("test-token", {
+      serverURL: "https://api.oursprivacy.com",
+      visitorId: "preset-visitor-bg",
+    });
+
+    op.track("Backgrounded Event", {step: 1});
+    await flushAsyncWork();
+
+    expect(appState.handler).toEqual(expect.any(Function));
+    expect(fetchMock.mock.calls).toHaveLength(0);
+
+    // Simulate the OS pushing the app to background.
+    appState.handler("background");
+
+    await waitForFetchCalls(1);
+
+    const [url, options] = fetchMock.mock.calls[0];
+    const body = JSON.parse(options.body);
+    expect(url).toBe("https://api.oursprivacy.com/ingest");
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].event).toBe("Backgrounded Event");
+  });
+
+  it("does not flush on transitions that are not background/inactive", async () => {
+    fetchMock.mockResponse(JSON.stringify({success: true}), {status: 200});
+
+    const appState = installAppStateCapture();
+
+    const {OursPrivacy} = require("oursprivacy-react-native");
+    const op = new OursPrivacy();
+
+    await op.init("test-token", {
+      serverURL: "https://api.oursprivacy.com",
+      visitorId: "preset-visitor-bg2",
+    });
+
+    op.track("Foreground Only", {step: 1});
+    await flushAsyncWork();
+
+    appState.handler("active");
+    await flushAsyncWork();
+
+    expect(fetchMock.mock.calls).toHaveLength(0);
   });
 });

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 "use strict";
 
-import {Platform} from "react-native";
 import OursPrivacyMain from "./javascript/oursprivacy-main"
 
 const ERROR_MESSAGE = {
@@ -82,18 +81,12 @@ export class OursPrivacy {
   }
 
   /**
-   * Compatibility API retained from the earlier native-backed SDK surface.
-   * In the current JavaScript runtime this is a safe no-op.
+   * Enable or disable flushing the event queue when the app moves to the
+   * background. Enabled by default. Works on iOS and Android via AppState.
    */
   setFlushOnBackground(flushOnBackground) {
     this._requireInit();
-    if (Platform.OS === "ios") {
-      this.oursprivacyImpl.setFlushOnBackground(this.token, flushOnBackground);
-    } else {
-      console.warn(
-        "OursPrivacy setFlushOnBackground was called and ignored because this method only works on iOS."
-      );
-    }
+    this.oursprivacyImpl.setFlushOnBackground(this.token, flushOnBackground);
   }
 
   /**

--- a/javascript/oursprivacy-main.js
+++ b/javascript/oursprivacy-main.js
@@ -1,4 +1,4 @@
-import {Platform, Dimensions} from "react-native";
+import {Platform, Dimensions, AppState} from "react-native";
 import {OursPrivacyCore} from "./oursprivacy-core";
 import {OursPrivacyType} from "./oursprivacy-constants";
 import {OursPrivacyConfig} from "./oursprivacy-config";
@@ -45,6 +45,8 @@ export default class OursPrivacyMain {
     this._defaultUserCustomProperties = {};
     this._defaultUserConsentProperties = {};
     this._attributionDefaultProperties = {};
+    this._flushOnBackgroundEnabled = true;
+    this._appStateSubscription = null;
   }
 
   /**
@@ -65,6 +67,20 @@ export default class OursPrivacyMain {
     await this._setOptedOutTrackingFlag(token, !!options.optOutTrackingByDefault);
 
     await this._applyInitializationOptions(token, options);
+
+    this._subscribeToAppState(token);
+  }
+
+  _subscribeToAppState(token) {
+    if (this._appStateSubscription || !AppState || typeof AppState.addEventListener !== "function") {
+      return;
+    }
+    this._appStateSubscription = AppState.addEventListener("change", (nextState) => {
+      if (!this._flushOnBackgroundEnabled) return;
+      if (nextState === "background") {
+        this.flush(token);
+      }
+    });
   }
 
   /**
@@ -200,9 +216,10 @@ export default class OursPrivacyMain {
   }
 
   setFlushOnBackground(token, flushOnBackground) {
+    this._flushOnBackgroundEnabled = !!flushOnBackground;
     OursPrivacyLogger.log(
       token,
-      `setFlushOnBackground(${String(flushOnBackground)}) is ignored in JavaScript mode.`
+      `Set flushOnBackground: ${this._flushOnBackgroundEnabled}`
     );
   }
 


### PR DESCRIPTION
## Summary
- Subscribe to `AppState` during `init()` and flush the queue when the app transitions to `background`.
- Enabled by default; `setFlushOnBackground(false)` opts out. Works on iOS and Android.

OUR-4098

## Test plan
- [x] `npm test` (111/111 pass) — adds two integration tests covering the background flush and the no-flush-on-active case
- [x] `npm run typecheck`