### PR TITLE
release: 3.1.0

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -91,13 +91,16 @@ jobs:
 
   # Publish runs in an isolated job: no `npm ci`, no project deps loaded.
   # `npm publish <tarball>` does not execute package lifecycle scripts, so
-  # no third-party JS runs in this job's env where NPM_TOKEN is present.
+  # no third-party JS runs in this job's env. Auth is via npm Trusted
+  # Publisher (OIDC) — the GitHub OIDC token is exchanged for a short-lived
+  # npm publish token at publish time, so no long-lived NPM_TOKEN is needed.
   publish:
     name: Publish to npm
     runs-on: ubuntu-latest
     needs: build
     permissions:
       contents: write # push release tag, create GitHub release
+      id-token: write # OIDC token for npm Trusted Publisher + provenance
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -118,8 +121,7 @@ jobs:
       - name: Publish tarball to npm
         env:
           VERSION: ${{ needs.build.outputs.version }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish "oursprivacy-react-native-${VERSION}.tgz" --access public
+        run: npm publish "oursprivacy-react-native-${VERSION}.tgz" --access public --provenance
 
       - name: Create git tag and GitHub release
         env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oursprivacy/react-native",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oursprivacy/react-native",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oursprivacy/react-native",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Official React Native Tracking Library for OursPrivacy Analytics",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
## Summary
- Bump to 3.1.0 — new feature: flush queued events when the app moves to background (#45)
- Dev-dep + CI maintenance: eslint 10.4.0 (#51), zizmor-action 0.5.6 (#50), qs/jest in Demo (#49, #48)
- Docs: deep link section TOC + replace semantics (#44)
- Repo: add CODEOWNERS (#46)
- CI: publish workflow switched to npm Trusted Publisher (OIDC) with provenance; no long-lived `NPM_TOKEN` needed

## Test plan
- [x] CI test + typecheck pass on dev
- [ ] Verify npm Trusted Publisher is saved on npmjs.com for `@oursprivacy/react-native` (workflow `publish-npm.yml`, repo `with-ours/ours-privacy-react-native`)
- [ ] On merge, publish workflow tags v3.1.0 and publishes `@oursprivacy/react-native@3.1.0` to npm with provenance