### PR TITLE
ci(dependabot): group action bumps, set dev prefix, skip majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,8 @@
-# Supply-chain hardening: Dependabot opens PRs to keep GitHub Actions
-# pinned to current commit SHAs.
+# Dependabot keeps GitHub Actions pinned to SHAs and npm dependencies fresh.
 #
-# When Dependabot proposes a bump, the PR will include the action's resolved
-# commit SHA with a trailing version comment (e.g.
-# `uses: actions/checkout@<40-char SHA> # v6.0.2`). Accept those PRs to land
+# Action bumps: the resolved PR includes the action's commit SHA with a
+# trailing version comment (e.g.
+# `uses: actions/checkout@<40-char SHA> # v6.0.2`). Accept these to keep
 # SHA pinning across this repo's workflows.
 
 version: 2
@@ -21,10 +20,13 @@ updates:
       - "github-actions"
     commit-message:
       prefix: "fix"
-    # GitHub recommends pinning by SHA for supply-chain safety. Dependabot
-    # honors this when the existing reference is a SHA; for refs that are
-    # still on a major-tag float, the first Dependabot PR will replace the
-    # float with a SHA pin. After that, weekly bumps land as SHA-to-SHA.
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "npm"
     directory: "/"
@@ -39,6 +41,7 @@ updates:
       - "npm"
     commit-message:
       prefix: "fix"
+      prefix-development: "chore"
     groups:
       dev-dependencies:
         dependency-type: "development"
@@ -50,6 +53,10 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: "npm"
     directory: "/Demo"
@@ -72,3 +79,7 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
## Summary
- Group minor/patch GitHub Action bumps into one weekly PR (currently each action is its own PR).
- Use `chore:` prefix for npm devDependency bumps; `fix:` stays for production deps.
- Skip semver-major bumps so they don't pile up in the PR queue (majors need manual review anyway).

## Test plan
- [ ] CI passes (no behavior change; only Dependabot config).
- [ ] Next weekly Dependabot run produces one grouped Actions PR and the expected npm group PRs.